### PR TITLE
Type-sensitive suggestion arg names

### DIFF
--- a/packages/Sandblocks-Smalltalk/SBStMessageSend.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStMessageSend.class.st
@@ -446,7 +446,7 @@ SBStMessageSend >> printOn: aStream [
 { #category : #'as yet unclassified' }
 SBStMessageSend >> receiver [
 
-	(self owner notNil and: [self isInCascade]) ifTrue: [self owner receiver].
+	(self owner notNil and: [self isInCascade]) ifTrue: [^ self owner receiver].
 	self submorphCount = 2 ifTrue: [^ self firstSubmorph].
 	^ nil
 ]

--- a/packages/Sandblocks-Smalltalk/SBStMessageSend.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStMessageSend.class.st
@@ -446,7 +446,6 @@ SBStMessageSend >> printOn: aStream [
 { #category : #'as yet unclassified' }
 SBStMessageSend >> receiver [
 
-	(self owner notNil and: [self isInCascade]) ifTrue: [^ self owner receiver].
 	self submorphCount = 2 ifTrue: [^ self firstSubmorph].
 	^ nil
 ]

--- a/packages/Sandblocks-Smalltalk/SBStNewMessageSend.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStNewMessageSend.class.st
@@ -245,8 +245,16 @@ SBStNewMessageSend >> pc: aNumber [
 { #category : #'as yet unclassified' }
 SBStNewMessageSend >> possibleArgumentNamesFor: aString [
 
-	(self systemNavigation allImplementorsOf: aString asSymbol) do: [:impl | ^ impl compiledMethod asSandblock arguments collect: #contents].
-	^ #()
+	| selector method |
+	selector := aString asSymbol.
+	self owner receiver guessClassExpensive ifNotNil: [:class | (class lookupSelector: selector) ifNotNil: [:meth | method := meth]].
+	method ifNil: [
+		method := (self systemNavigation allImplementorsOf: selector)
+			at: 1
+			ifPresent: [:ref | ref compiledMethod]
+			ifAbsent: [nil]].
+	method ifNil: [^ #()].
+	^ method asSandblock arguments collect: #contents
 ]
 
 { #category : #accessing }

--- a/packages/Sandblocks-Smalltalk/SBStNewMessageSend.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStNewMessageSend.class.st
@@ -247,7 +247,7 @@ SBStNewMessageSend >> possibleArgumentNamesFor: aString [
 
 	| selector method |
 	selector := aString asSymbol.
-	self owner receiver guessClassExpensive ifNotNil: [:class | (class lookupSelector: selector) ifNotNil: [:meth | method := meth]].
+	(self owner receiver ifNotNil: [:b | b guessClassExpensive]) ifNotNil: [:class | (class lookupSelector: selector) ifNotNil: [:meth | method := meth]].
 	method ifNil: [
 		method := (self systemNavigation allImplementorsOf: selector)
 			at: 1

--- a/packages/Sandblocks-Smalltalk/SBStSignature.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStSignature.class.st
@@ -248,8 +248,18 @@ SBStSignature >> objectInterfaceNear: aBlock at: aSymbol argumentInterface: anIn
 { #category : #'as yet unclassified' }
 SBStSignature >> possibleArgumentNamesFor: aString [
 
-	(self systemNavigation allImplementorsOf: aString asSymbol) do: [:impl | ^ impl compiledMethod asSandblock arguments collect: #contents].
-	^ #()
+	| selector method |
+	selector := aString asSymbol.
+	
+	self owner receiver guessClassExpensive ifNotNil: [:class | (class lookupSelector: selector) ifNotNil: [:meth | method := meth]].
+	method ifNil: [
+		method := (self systemNavigation allImplementorsOf: selector)
+			at: 1
+			ifPresent: [:ref | ref compiledMethod]
+			ifAbsent: [nil]].
+	method ifNil: [^ #()].
+	
+	^ method asSandblock arguments collect: #contents
 ]
 
 { #category : #'submorphs - callbacks' }

--- a/packages/Sandblocks-Smalltalk/SBStSignature.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStSignature.class.st
@@ -251,7 +251,7 @@ SBStSignature >> possibleArgumentNamesFor: aString [
 	| selector method |
 	selector := aString asSymbol.
 	
-	self owner receiver guessClassExpensive ifNotNil: [:class | (class lookupSelector: selector) ifNotNil: [:meth | method := meth]].
+	(self owner receiver ifNotNil: [:b | b guessClassExpensive]) ifNotNil: [:class | (class lookupSelector: selector) ifNotNil: [:meth | method := meth]].
 	method ifNil: [
 		method := (self systemNavigation allImplementorsOf: selector)
 			at: 1


### PR DESCRIPTION
st: honor guessed class for mining of possible argument names 

Testing:

	Morph new click: ...
	ListStub new click: ...

The argument name should be chosen from the right implementation preferably. The previous detection mechanism proposed to wrong name.


However, this solution is still not perfect IMHO. Depending on the situation, less confusion might be caused by eliminating the second pass via #systemNavigation entirely, i.e., providing no custom argument names at all if type guessing failed. Wdyt?

Also, what would be a proper place to eliminate the duplication between SbStNewMessageSend and SBStSignature?