### PR TITLE
core/st: add UI for projection suggestions

### DIFF
--- a/packages/Sandblocks-Core/SBProjectionSuggestionItem.class.st
+++ b/packages/Sandblocks-Core/SBProjectionSuggestionItem.class.st
@@ -1,0 +1,63 @@
+Class {
+	#name : #SBProjectionSuggestionItem,
+	#superclass : #SBSuggestionItem,
+	#category : #'Sandblocks-Core'
+}
+
+{ #category : #geometry }
+SBProjectionSuggestionItem >> fontHeight [
+
+	^ self fontToUse height
+]
+
+{ #category : #initialization }
+SBProjectionSuggestionItem >> initialize [
+
+	super initialize.
+	self addMorph: self makeRoomForLabel
+]
+
+{ #category : #accessing }
+SBProjectionSuggestionItem >> instance [
+
+	^ self roomForLabel submorphAfter
+]
+
+{ #category : #accessing }
+SBProjectionSuggestionItem >> instanceSuggestion: factory [
+
+	| instance |
+	self removeAllButFirstSubmorph.
+	factory ifNil: [^ self].
+	
+	instance := (factory value
+		in: [:block |
+			block extent: block minExtent.
+			
+			];
+		imageForm) asMorph.
+	self addMorphBack: instance.
+	instance position: self firstSubmorph bottomLeft
+]
+
+{ #category : #initialization }
+SBProjectionSuggestionItem >> makeRoomForLabel [
+
+	^ Morph new
+		beTransparent;
+		position: self layoutBounds origin;
+		height: self fontHeight
+]
+
+{ #category : #layout }
+SBProjectionSuggestionItem >> minExtent [
+
+	self instance ifNil: [^ super minExtent].
+	^ super minExtent + self instance height
+]
+
+{ #category : #accessing }
+SBProjectionSuggestionItem >> roomForLabel [
+
+	^ self firstSubmorph
+]

--- a/packages/Sandblocks-Smalltalk/SBColor.class.st
+++ b/packages/Sandblocks-Smalltalk/SBColor.class.st
@@ -8,7 +8,13 @@ Class {
 	#category : #'Sandblocks-Smalltalk'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #suggestions }
+SBColor class >> instanceSuggestion [
+
+	^ [self new colorContents: (Color r: 1 g: 0.0 b: 0.0)]
+]
+
+{ #category : #testing }
 SBColor class >> matches: aMessage [
 
 	SBExample
@@ -30,20 +36,10 @@ SBColor class >> matches: aMessage [
 		ifFalse: [(aMessage selector = 'r:g:b:' or: [aMessage selector = 'r:g:b:a:' or: [aMessage selector = 'fromString:']]) and: [aMessage arguments allSatisfy: #isLiteralBlock]]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'instance creation' }
 SBColor class >> newFor: aMessage [
 
 	^ self new colorContents: aMessage evaluate
-]
-
-{ #category : #'as yet unclassified' }
-SBColor class >> suggestion [
-
-	^ [:block |
-		block sandblockEditor do: (SBReplaceCommand new
-			target: block;
-			replacer: (self new colorContents: Color red);
-			yourself)]
 ]
 
 { #category : #'as yet unclassified' }

--- a/packages/Sandblocks-Smalltalk/SBExpandedMethod.class.st
+++ b/packages/Sandblocks-Smalltalk/SBExpandedMethod.class.st
@@ -4,25 +4,25 @@ Class {
 	#category : #'Sandblocks-Smalltalk'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 SBExpandedMethod class >> applyAutomatically [
 
 	^ false
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 SBExpandedMethod class >> matches: aBlock [
 
 	^ super matches: aBlock
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'instance creation' }
 SBExpandedMethod class >> newFor: aBlock [
 
 	^ self new send: aBlock
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBExpandedMethod class >> priority [
 
 	^ 3

--- a/packages/Sandblocks-Smalltalk/SBForm.class.st
+++ b/packages/Sandblocks-Smalltalk/SBForm.class.st
@@ -9,7 +9,7 @@ Class {
 	#category : #'Sandblocks-Smalltalk'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 SBForm class >> matches: aBlock [
 
 	(super matches: aBlock) ifFalse: [^ false].
@@ -20,7 +20,7 @@ SBForm class >> matches: aBlock [
 		and: [aBlock arguments first isStringBlock]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'instance creation' }
 SBForm class >> newFor: aBlock [
 
 	^ self new filename: aBlock arguments first contents

--- a/packages/Sandblocks-Smalltalk/SBHalt.class.st
+++ b/packages/Sandblocks-Smalltalk/SBHalt.class.st
@@ -14,7 +14,13 @@ SBHalt class >> deactivated [
 	" marker "
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #suggestions }
+SBHalt class >> instanceSuggestion [
+
+	^ [self new]
+]
+
+{ #category : #testing }
 SBHalt class >> matches: aBlock [
 
 	(super matches: aBlock) ifFalse: [^ false].
@@ -22,19 +28,10 @@ SBHalt class >> matches: aBlock [
 	^ (aBlock selector = 'sandblocksHalt' and: [aBlock receiver notNil]) or: [(aBlock receiver satisfies: #(#notNil #isName)) and: [aBlock receiver contents = 'SBHalt' and: [aBlock selector = #deactivated]]]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'instance creation' }
 SBHalt class >> newFor: aBlock [
 
 	^ self new active: aBlock selector ~= #deactivated
-]
-
-{ #category : #'as yet unclassified' }
-SBHalt class >> suggestion [
-
-	^ [:block |
-		block sandblockEditor do: (SBReplaceCommand new
-			target: block;
-			replacer: SBHalt new)]
 ]
 
 { #category : #'as yet unclassified' }

--- a/packages/Sandblocks-Smalltalk/SBIconPicker.class.st
+++ b/packages/Sandblocks-Smalltalk/SBIconPicker.class.st
@@ -7,7 +7,7 @@ Class {
 	#category : #'Sandblocks-Smalltalk'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 SBIconPicker class >> matches: aBlock [
 
 	(super matches: aBlock) ifFalse: [^ false].
@@ -18,7 +18,7 @@ SBIconPicker class >> matches: aBlock [
 	}
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'instance creation' }
 SBIconPicker class >> newFor: aBlock [
 
 	^ self new icon: aBlock selector

--- a/packages/Sandblocks-Smalltalk/SBMemoize.class.st
+++ b/packages/Sandblocks-Smalltalk/SBMemoize.class.st
@@ -10,13 +10,13 @@ Class {
 	#category : #'Sandblocks-Smalltalk'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #private }
 SBMemoize class >> cache [
 
 	^ Cache ifNil: [Cache := Dictionary new]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'instance creation' }
 SBMemoize class >> do: aBlock identifier: aNumber [
 
 	^ self cache
@@ -28,20 +28,29 @@ SBMemoize class >> do: aBlock identifier: aNumber [
 			value]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #examples }
 SBMemoize class >> example [
 
 	SBMemoize do: [WebClient httpGet: 'https://google.com'] identifier: 123123
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #suggestions }
+SBMemoize class >> instanceSuggestion [
+
+	^ [
+		self new
+			expression: SBStGrammarHandler new newNullBlock;
+			identifier: self newIdentifier]
+]
+
+{ #category : #testing }
 SBMemoize class >> matches: aMessageSend [
 
 	(super matches: aMessageSend) ifFalse: [^ false].
 	^ self selector: 'do:identifier:' receiverMatches: aMessageSend
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'instance creation' }
 SBMemoize class >> newFor: aMessageSend [
 
 	| args |
@@ -50,6 +59,15 @@ SBMemoize class >> newFor: aMessageSend [
 		expression: args first;
 		identifier: args second parsedContents;
 		yourself
+]
+
+{ #category : #private }
+SBMemoize class >> newIdentifier [
+
+	| i |
+	i := self cache size.
+	[self cache includesKey: i] whileTrue: [i := i + 1].
+	^ i
 ]
 
 { #category : #'as yet unclassified' }

--- a/packages/Sandblocks-Smalltalk/SBPoint.class.st
+++ b/packages/Sandblocks-Smalltalk/SBPoint.class.st
@@ -11,7 +11,13 @@ Class {
 	#category : #'Sandblocks-Smalltalk'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #suggestions }
+SBPoint class >> instanceSuggestion [
+
+	^ [self new]
+]
+
+{ #category : #testing }
 SBPoint class >> matches: aBlock [
 
 	(aBlock isKindOf: SBPoint) ifTrue: [^ true].
@@ -21,7 +27,7 @@ SBPoint class >> matches: aBlock [
 	^ (aBlock selector = '@' or: [aBlock selector = ',']) and: [aBlock receiver isNumberBlock] and: [aBlock arguments first isNumberBlock]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'instance creation' }
 SBPoint class >> newFor: aBlock [
 
 	(aBlock isKindOf: SBPoint) ifTrue: [^ aBlock veryDeepCopy].
@@ -31,7 +37,7 @@ SBPoint class >> newFor: aBlock [
 		type: Point
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'instance creation' }
 SBPoint class >> newForPoint: aPoint [
 
 	^ self new
@@ -39,7 +45,14 @@ SBPoint class >> newForPoint: aPoint [
 		type: Point
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'instance creation' }
+SBPoint class >> newWithUnknown [
+
+	self flag: #broken.
+	^ self new addMorph: SBStMessageSend new
+]
+
+{ #category : #accessing }
 SBPoint class >> priority [
 
 	^ 21000

--- a/packages/Sandblocks-Smalltalk/SBStLanguageBox.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStLanguageBox.class.st
@@ -4,23 +4,32 @@ Class {
 	#category : #'Sandblocks-Smalltalk'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #suggestions }
+SBStLanguageBox class >> instanceSuggestion [
+
+	^ [
+		SBStLanguageBox new
+			source: '' lang: 'scheme';
+			yourself]
+]
+
+{ #category : #testing }
 SBStLanguageBox class >> matches: aMessageSend [
 
 	^ (false) and: [aMessageSend selector = 'eval:lang:']
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'instance creation' }
 SBStLanguageBox class >> newFor: aBlock [
 
 	^ self new source: aBlock arguments first contents lang: aBlock arguments second contents
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #suggestions }
 SBStLanguageBox class >> suggestion [
 
 	^ [:block | | box |
-		box := SBStLanguageBox new source: '' lang: 'scheme'.
+		box := self instanceSuggestion value.
 		block sandblockEditor do: (SBReplaceCommand new
 			target: block;
 			replacer: box).

--- a/packages/Sandblocks-Smalltalk/SBStNameBehavior.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStNameBehavior.class.st
@@ -304,7 +304,12 @@ SBStNameBehavior >> uppercaseSuggestions [
 				stream nextPut: (SBSuggestionItem selector: key label: ((value isBehavior and: [key == value name])
 					ifTrue: ['class']
 					ifFalse: ['global']))]].
-		SBStSubstitution allSubclassesDo: [:class | (class name sandblockMatch: self contents) ifTrue: [class suggestion ifNotNil: [:block | stream nextPut: ((SBSuggestionItem selector: class name label: 'projection') completionAction: block)]]]]
+		SBStSubstitution allSubclassesDo: [:class |
+			(class name sandblockMatch: self contents) ifTrue: [
+				class suggestion ifNotNil: [:block |
+					stream nextPut: ((SBProjectionSuggestionItem selector: class name label: 'projection')
+						completionAction: block;
+						instanceSuggestion: class instanceSuggestion)]]]]
 ]
 
 { #category : #'as yet unclassified' }

--- a/packages/Sandblocks-Smalltalk/SBStRegex.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStRegex.class.st
@@ -9,7 +9,13 @@ Class {
 	#category : #'Sandblocks-Smalltalk'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
+SBStRegex class >> instanceSuggestion [
+
+	^ [self new regexString: '' examples: #()]
+]
+
+{ #category : #testing }
 SBStRegex class >> matches: aBlock [
 
 	(super matches: aBlock) ifFalse: [^ false].
@@ -18,7 +24,7 @@ SBStRegex class >> matches: aBlock [
 	[(aBlock receiver satisfies: #(notNil isBinding)) and: [aBlock receiver contents = self name] and: [aBlock selector = 'regex:examples:']]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'instance creation' }
 SBStRegex class >> newFor: aBubble [
 
 	^ aBubble selector = 'asRegex'
@@ -30,7 +36,7 @@ SBStRegex class >> newFor: aBubble [
 				examples: (aBubble arguments second childSandblocks collect: #contents)]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'instance creation' }
 SBStRegex class >> regex: aRegex examples: aCollection [
 
 	^ aRegex asRegex
@@ -84,7 +90,7 @@ SBStRegex >> createExample: aString [
 { #category : #'as yet unclassified' }
 SBStRegex >> currentTextMorph [
 
-	^ text
+	^ text currentTextMorph
 ]
 
 { #category : #'as yet unclassified' }

--- a/packages/Sandblocks-Smalltalk/SBStSubstitution.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStSubstitution.class.st
@@ -7,19 +7,19 @@ Class {
 	#category : #'Sandblocks-Smalltalk'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 SBStSubstitution class >> applyAutomatically [
 
 	^ true
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 SBStSubstitution class >> catchesAll [
 
 	^ false
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 SBStSubstitution class >> causesSideEffects [
 
 	^ false
@@ -31,67 +31,80 @@ SBStSubstitution class >> derive: anObject [
 	^ anObject
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 SBStSubstitution class >> identity [
 
 	^ false
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #suggestions }
+SBStSubstitution class >> instanceSuggestion [
+	"Answer a factory block that creates a new instance of the receiver. To be overridden by subclasses."
+
+	^ nil
+]
+
+{ #category : #testing }
 SBStSubstitution class >> isLeaf [
 
 	^ true
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 SBStSubstitution class >> isSmalltalkExpression [
 
 	^ true
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 SBStSubstitution class >> matches: aMessageSend [
 
 	^ aMessageSend isSandblock and: [(aMessageSend isMessageSend and: [aMessageSend receiver notNil]) or: [self matchesCascades and: [aMessageSend isCascade]]]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 SBStSubstitution class >> matchesCascades [
 
 	^ false
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'instance creation' }
 SBStSubstitution class >> newFor: aMessage [
 
 	^ self subclassResponsibility
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBStSubstitution class >> prettyName [
 
 	^ self name allButFirst: 2
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBStSubstitution class >> priority [
 
 	^ 10
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 SBStSubstitution class >> selector: aString receiverMatches: aMessage [
 
 	^ (aMessage receiver satisfies: #(notNil isBinding)) and: [self name = aMessage receiver contents and: [aMessage selector = aString]]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #suggestions }
 SBStSubstitution class >> suggestion [
+	"Answer a completion block that inserts a new instance of the receiver into a provided block. Subclasses may override this, but in many cases only need to override #instanceSuggestion."
 
-	^ nil
+	^ self instanceSuggestion ifNotNil: [:factory |
+		[:block |
+			block sandblockEditor do: (SBReplaceCommand new
+				target: block;
+				replacer: factory value;
+				yourself)]]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 SBStSubstitution class >> supports: aSymbol [
 
 	^ (self respondsTo: aSymbol) and: [self perform: aSymbol]

--- a/packages/Sandblocks-Smalltalk/SBStateMachineEditor.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStateMachineEditor.class.st
@@ -9,7 +9,13 @@ Class {
 	#category : #'Sandblocks-Smalltalk'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #suggestions }
+SBStateMachineEditor class >> instanceSuggestion [
+
+	^ [SBStateMachineEditor new]
+]
+
+{ #category : #testing }
 SBStateMachineEditor class >> matches: aNode [
 
 	(super matches: aNode) ifFalse: [^ false].
@@ -17,26 +23,16 @@ SBStateMachineEditor class >> matches: aNode [
 	^ aNode isCascade and: [aNode receiver isMessageSend and: [aNode receiver receiver isName and: [aNode receiver receiver contents = 'SBStateMachine' and: [aNode receiver selector = 'new']]]]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 SBStateMachineEditor class >> matchesCascades [
 
 	^ true
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'instance creation' }
 SBStateMachineEditor class >> newFor: aNode [
 
 	^ self new buildFrom: aNode
-]
-
-{ #category : #'as yet unclassified' }
-SBStateMachineEditor class >> suggestion [
-
-	^ [:block |
-		block sandblockEditor do: (SBReplaceCommand new
-			target: block;
-			replacer: SBStateMachineEditor new;
-			yourself)]
 ]
 
 { #category : #'as yet unclassified' }

--- a/packages/Sandblocks-Smalltalk/SBToggledCode.class.st
+++ b/packages/Sandblocks-Smalltalk/SBToggledCode.class.st
@@ -7,13 +7,19 @@ Class {
 	#category : #'Sandblocks-Smalltalk'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #'instance creation' }
 SBToggledCode class >> comment: aString active: aNumber do: aCollection [
 
 	^ aNumber > 0 ifTrue: [(aCollection at: aNumber) value] ifFalse: [nil]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #suggestions }
+SBToggledCode class >> instanceSuggestion [
+
+	^ [self newEmpty]
+]
+
+{ #category : #testing }
 SBToggledCode class >> matches: aBlock [
 
 	(super matches: aBlock) ifFalse: [^ false].
@@ -21,7 +27,13 @@ SBToggledCode class >> matches: aBlock [
 	^ aBlock receiver isBinding and: [aBlock receiver contents = 'SBToggledCode'] and: [aBlock selector = 'comment:active:do:']
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'instance creation' }
+SBToggledCode class >> newEmpty [
+
+	^ self new comment: '' active: 0 do: {SBStBlockBody new}
+]
+
+{ #category : #'instance creation' }
 SBToggledCode class >> newFor: aBlock [
 
 	^ self new


### PR DESCRIPTION
A projection suggestion is an item in a suggestion menu like a normal suggestion but will insert a substitution when chosen for completion. With this patch, projections appear with a small preview in the suggestions menu that should make the choice more intuitive for users.

Besides, on the class-side protocol of st substitutions, `#instanceSuggestion` is extracted which answers a factory block for a new instance, making it easier for subclasses to provide their suggestions.

Suggestions are added to the substitutions memoize, point, language box, regex, and toggled code.

![image](https://user-images.githubusercontent.com/38782922/149856885-0134114f-0932-4bbb-b80d-6ba1c2e9f35f.png) ![image](https://user-images.githubusercontent.com/38782922/149856917-711ebe4a-a819-4bcc-bd9f-a37446860c8b.png) ![SBToggledCode-suggestion](https://user-images.githubusercontent.com/38782922/149857359-933c74c3-3e61-482d-9ee4-3a451b29a1af.gif)
´

Open issues (ideally to be addressed while/before merging this):

- [ ] Previewed blocks are not styled correctly (note that I replaced them by an `#imageForm` as a simple way of locking them with all their submorphs against any kind of event handling - is there a better way to do this?)

Ideas for later:

- Union the knowledge bases from `instanceSuggestion`s and palettes
- Provide these suggestions without using the explicit protocol from the substitutions classes. For instance, `String >> #asRegex` could also be completed with the regex substitution, or `Color >> #red/#green/#r:g:b:`/whatever else could be completed with a color substitution. As a general, is there already an "automatic substitution" mode? :)