### PR TITLE
core: revise opening of suggestions menu, always open in world + reposition

### DIFF
--- a/packages/Sandblocks-Core/SBBlock.class.st
+++ b/packages/Sandblocks-Core/SBBlock.class.st
@@ -2707,15 +2707,8 @@ SBBlock >> updateSuggestions: aCollection showNear: aMorph [
 
 	(aCollection isEmpty or: [self hasInput not]) ifTrue: [^ self removeSuggestionMenu].
 	
-	self sandblockEditor ifNil: [^ self].
-	
-	self suggestionsMenu
-		editor: self sandblockEditor;
-		suggestions: (aCollection take: 30);
-		topLeft: aMorph position + (0 @ aMorph height).
-	
-	self sandblockEditor openMorph: self suggestionsMenu.
-	self suggestionsMenu resize
+	self suggestionsMenu suggestions: (aCollection take: 50).
+	self sandblockEditor ifNotNil: [:editor | editor showSuggestionsMenu: self suggestionsMenu near: aMorph]
 ]
 
 { #category : #layout }

--- a/packages/Sandblocks-Core/SBEditor.class.st
+++ b/packages/Sandblocks-Core/SBEditor.class.st
@@ -348,7 +348,7 @@ SBEditor >> click: anEvent [
 	self select: nil
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'insert/delete' }
 SBEditor >> close [
 
 	self containingWindow ifNotNil: #delete.
@@ -774,7 +774,7 @@ SBEditor >> handlesMouseDown: anEvent [
 	^ true
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'event handling' }
 SBEditor >> handlesMouseOver: anEvent [
 
 	^ true
@@ -860,7 +860,7 @@ SBEditor >> inputIsDefault [
 	^ inputMapping defaultState = #input
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'insert/delete' }
 SBEditor >> insertCommandRequest: aMorph near: aBlock before: aBoolean [
 
 	^ SBEditorOpenMorphCommand new
@@ -958,14 +958,14 @@ SBEditor >> modelWakeUp [
 		self valueOfProperty: #previousWindow ifPresentDo: [:window | self owner addMorphFront: self]]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBEditor >> morphicLayerNumber [
 	" make sure we're at least over the docking bar "
 
 	^ 77 - 1
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'event handling' }
 SBEditor >> mouseLeave: anEvent [
 
 	hoverHighlight ifNotNil: #detach
@@ -1024,7 +1024,7 @@ SBEditor >> objectInterface [
 	^ SBInterfaces never
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'object interface' }
 SBEditor >> objectInterfaceNear: aBlock at: aSymbol [
 
 	^ SBInterfaces block, (SBToggledCode comment: '' active: 1 do: {[SBInterfaces always]. [SBInterfaces topLevel]})
@@ -1414,7 +1414,7 @@ SBEditor >> scrollToShow: aBlock [
 		scroll scrollToShow: aBlock]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBEditor >> scrollerClass [
 
 	^ SBEditorCanvasWithOverlay
@@ -1456,6 +1456,18 @@ SBEditor >> selection [
 SBEditor >> showHelper [
 
 	(helpOverlay isNil and: [self isInWorld and: [self selection notNil]]) ifTrue: [helpOverlay := SBHelpOverlay new target: self selection]
+]
+
+{ #category : #suggestions }
+SBEditor >> showSuggestionsMenu: menu near: aMorph [
+	"Hook for subclasses."
+
+	menu
+		editor: self;
+		topLeft: aMorph position + (0 @ aMorph height).
+	
+	self openMorph: menu.
+	menu resize
 ]
 
 { #category : #selection }

--- a/packages/Sandblocks-Core/SBEditor.class.st
+++ b/packages/Sandblocks-Core/SBEditor.class.st
@@ -1319,6 +1319,16 @@ SBEditor >> reportErrorWithProcessCopy: anError source: anExecutableEnvironment 
 		source: anExecutableEnvironment
 ]
 
+{ #category : #suggestions }
+SBEditor >> repositionSuggestionsMenu [
+
+	| menu reference |
+	menu := self valueOfProperty: #sandblockSuggestionMenu ifAbsent: [^ self].
+	reference := self valueOfProperty: #sandblockSuggestionMenuReference ifAbsent: [^ self].
+	menu topLeft: reference positionInWorld + (0 @ reference height).
+	menu resize
+]
+
 { #category : #initialization }
 SBEditor >> resetState [
 
@@ -1460,14 +1470,14 @@ SBEditor >> showHelper [
 
 { #category : #suggestions }
 SBEditor >> showSuggestionsMenu: menu near: aMorph [
-	"Hook for subclasses."
 
-	menu
-		editor: self;
-		topLeft: aMorph position + (0 @ aMorph height).
+	menu editor: self.
 	
-	self openMorph: menu.
-	menu resize
+	self
+		setProperty: #sandblockSuggestionMenu toValue: menu;
+		setProperty: #sandblockSuggestionMenuReference toValue: aMorph.
+	self repositionSuggestionsMenu.
+	menu openInWorld
 ]
 
 { #category : #selection }
@@ -1497,6 +1507,18 @@ SBEditor >> startInput: aMorph at: aNumber replacingContents: aBoolean [
 SBEditor >> startOrAddToMultiSelection: aBlock [
 
 	self cursor startOrAddToMultiSelection: aBlock
+]
+
+{ #category : #stepping }
+SBEditor >> step [
+
+	self repositionSuggestionsMenu
+]
+
+{ #category : #stepping }
+SBEditor >> stepTime [
+
+	^ 0
 ]
 
 { #category : #printing }


### PR DESCRIPTION
As discussed. This prevents the suggestions menu from being clipped within the editor and at the same time makes sure it always appears at the right time when an artefact or the editor is moved.

See also:  https://github.com/tom95/sandblocks/commit/66e28689c4992a4707c78b4fbbab7b4c0a7ba573.

![sandblocks-#90](https://user-images.githubusercontent.com/38782922/149993075-5b24eebb-91d1-4629-8560-d707db483d06.gif)