### PR TITLE
core: mv `SBSuggestionMenu>>#active{Suggestion,Item}`

### DIFF
--- a/packages/Sandblocks-Core/SBBlock.class.st
+++ b/packages/Sandblocks-Core/SBBlock.class.st
@@ -2392,7 +2392,7 @@ SBBlock >> selectionLabel [
 { #category : #'actions tests' }
 SBBlock >> shouldAutocomplete [
 
-	^ self hasSuggestions and: [self suggestionsMenu activeSuggestion wouldChange: self]
+	^ self hasSuggestions and: [self suggestionsMenu activeItem wouldChange: self]
 ]
 
 { #category : #'as yet unclassified' }
@@ -2735,7 +2735,7 @@ SBBlock >> useSuggestion [
 
 	self suggestionMenuDo: [:menu | | editor |
 		editor := self sandblockEditor.
-		menu activeSuggestion ifNotNil: [:s |
+		menu activeItem ifNotNil: [:s |
 			(s wouldChange: self)
 				ifTrue: [
 					s useSuggestionOn: self.

--- a/packages/Sandblocks-Core/SBSuggestionItem.class.st
+++ b/packages/Sandblocks-Core/SBSuggestionItem.class.st
@@ -10,7 +10,7 @@ Class {
 	#category : 'Sandblocks-Core'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #'instance creation' }
 SBSuggestionItem class >> selector: aSymbol label: aString [
 
 	^ self new

--- a/packages/Sandblocks-Core/SBSuggestionMenu.class.st
+++ b/packages/Sandblocks-Core/SBSuggestionMenu.class.st
@@ -22,23 +22,25 @@ SBSuggestionMenu >> activeIndex [
 ]
 
 { #category : #accessing }
+SBSuggestionMenu >> activeItem [
+
+	^ self hasItems ifFalse: [nil] ifTrue: [self items at: activeIndex]
+]
+
+{ #category : #accessing }
 SBSuggestionMenu >> activeItem: anItem [
 
+	anItem = self activeItem ifTrue: [^ self].
+	
 	(self items at: activeIndex) active: false.
 	activeIndex := self items indexOf: anItem.
-	anItem active: true.
+	anItem active: true
 ]
 
 { #category : #accessing }
 SBSuggestionMenu >> activeSelector [
 
-	^ self activeSuggestion ifNotNil: #selector
-]
-
-{ #category : #accessing }
-SBSuggestionMenu >> activeSuggestion [
-
-	^ self hasItems ifFalse: [nil] ifTrue: [self items at: activeIndex]
+	^ self activeItem ifNotNil: #selector
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
In particular, add an early exit to `#activeItem:` to make `SBSuggestionItem >> #active:` a more meaningful hook. (Sonyx makes use of this hook in a subclass.)