### PR TITLE
core: fix tests by catching unhandled UndeclaredVariableWarnings

### DIFF
--- a/packages/Sandblocks-Babylonian/SBStTestCase.class.st
+++ b/packages/Sandblocks-Babylonian/SBStTestCase.class.st
@@ -248,7 +248,7 @@ SBStTestCase >> runTest [
 			do: [:err |
 				self reportError: err.
 				err return: false]
-			on: TestResult error
+			on: TestResult exError
 			do: [:err |
 				self reportError: err.
 				err return: false]) ifTrue: [

--- a/packages/Sandblocks-Core/SBASTNodeTest.class.st
+++ b/packages/Sandblocks-Core/SBASTNodeTest.class.st
@@ -4,11 +4,11 @@ Class {
 	#category : #'Sandblocks-Core-Tests'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 SBASTNodeTest >> testBindingRename [
 
 	| block editor |
-	block := '[|from to| from squared. from squared]' parseAsSandblock.
+	block := self parse: '[|from to| from squared. from squared]'.
 	editor := self methodFor: block.
 	
 	editor startInput: block statements last receiver at: 1 replacingContents: true.
@@ -19,11 +19,11 @@ SBASTNodeTest >> testBindingRename [
 	self assert: 'to' equals: block statements last receiver contents
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 SBASTNodeTest >> testCanClearMessagePart [
 
 	| block selection editor |
-	block := '[a + 5]' parseAsSandblock.
+	block := self parse: '[a + 5]'.
 	selection := block statements first messageParts first.
 	editor := (self methodFor: block) select: selection.
 	editor startInput: selection at: 1 replacingContents: true.
@@ -32,11 +32,11 @@ SBASTNodeTest >> testCanClearMessagePart [
 	self assert: selection parentSandblock isMessageSend
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 SBASTNodeTest >> testCanUndoAppendLine [
 
 	| block selection editor |
-	block := '[5]' parseAsSandblock.
+	block := self parse: '[5]'.
 	editor := self methodFor: block.
 	selection := block statements first.
 	selection performAction: #insertStatementBelow.
@@ -50,11 +50,11 @@ SBASTNodeTest >> testCanUndoAppendLine [
 	self assert: 1 equals: block statements size
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 SBASTNodeTest >> testChangeSendToAssignment [
 
 	| block selection editor |
-	block := '[a + 5]' parseAsSandblock.
+	block := self parse: '[a + 5]'.
 	selection := block statements first messageParts first.
 	editor := (self methodFor: block) select: selection.
 	editor startInput: selection at: 1 replacingContents: true.
@@ -64,11 +64,11 @@ SBASTNodeTest >> testChangeSendToAssignment [
 	self assert: block statements first isMessageSend not
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 SBASTNodeTest >> testInsertStatementAboveOrBelow [
 
 	| block selection |
-	block := '[5]' parseAsSandblock.
+	block := self parse: '[5]'.
 	selection := block statements first.
 	self methodFor: block.
 	selection performAction: #insertStatementBelow.
@@ -77,22 +77,22 @@ SBASTNodeTest >> testInsertStatementAboveOrBelow [
 	self assert: block statements first isUnknown
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 SBASTNodeTest >> testMergeMessages [
 
 	| block editor |
-	block := '[self assert: (5 equals: 3)]' parseAsSandblock.
+	block := self parse: '[self assert: (5 equals: 3)]'.
 	editor := self methodFor: block.
 	
 	block statements first arguments first performAction: #unwrapList.
 	self assert: #assert:equals: equals: block statements first selector
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 SBASTNodeTest >> testUndoChangeSendToAssignment [
 
 	| block selection editor |
-	block := '[a + 5]' parseAsSandblock.
+	block := self parse: '[a + 5]'.
 	selection := block statements first messageParts first.
 	editor := (self methodFor: block) select: selection.
 	editor startInput: selection at: 1 replacingContents: true.
@@ -105,11 +105,11 @@ SBASTNodeTest >> testUndoChangeSendToAssignment [
 	self assert: block statements first isMessageSend not
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 SBASTNodeTest >> testUndoWrapInArray [
 
 	| block selection editor |
-	block := '[self squared. self changeTableLayout. self resize]' parseAsSandblock.
+	block := self parse: '[self squared. self changeTableLayout. self resize]'.
 	selection := block statements first.
 	editor := self methodFor: block.
 	editor select: selection.
@@ -128,11 +128,11 @@ SBASTNodeTest >> testUndoWrapInArray [
 	self assert: block statements third receiver contents = 'self'
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 SBASTNodeTest >> testUndoWrapInBlock [
 
 	| block selection editor |
-	block := '[self squared. self changeTableLayout. self resize]' parseAsSandblock.
+	block := self parse: '[self squared. self changeTableLayout. self resize]'.
 	selection := block statements first.
 	editor := self methodFor: block.
 	editor select: selection.
@@ -151,11 +151,11 @@ SBASTNodeTest >> testUndoWrapInBlock [
 	self assert: block statements third receiver contents = 'self'
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 SBASTNodeTest >> testUndoWrapInCascade [
 
 	| block selection editor |
-	block := '[self squared. self changeTableLayout. self resize]' parseAsSandblock.
+	block := self parse: '[self squared. self changeTableLayout. self resize]'.
 	selection := block statements first.
 	editor := self methodFor: block.
 	editor startOrAddToMultiSelection: block statements first.
@@ -172,11 +172,11 @@ SBASTNodeTest >> testUndoWrapInCascade [
 	self assert: block statements third receiver contents = 'self'
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 SBASTNodeTest >> testWrapAsArgument [
 
 	| block selection |
-	block := '[5]' parseAsSandblock.
+	block := self parse: '[5]'.
 	self methodFor: block.
 	selection := block statements first.
 	selection performAction: #wrapAsArgument.
@@ -185,11 +185,11 @@ SBASTNodeTest >> testWrapAsArgument [
 	self assert: block statements first receiver isUnknown
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 SBASTNodeTest >> testWrapInArrayType [
 
 	| block selection |
-	block := '[5]' parseAsSandblock.
+	block := self parse: '[5]'.
 	selection := block statements first.
 	(self methodFor: block) select: selection.
 	selection performAction: #wrapInDynamicArray.
@@ -197,11 +197,11 @@ SBASTNodeTest >> testWrapInArrayType [
 	self assert: block statements first firstSubmorph = selection
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 SBASTNodeTest >> testWrapInBlock [
 
 	| block selection |
-	block := '[5]' parseAsSandblock.
+	block := self parse: '[5]'.
 	selection := block statements first.
 	(self methodFor: block) select: selection.
 	selection performAction: #wrapInBlock.
@@ -209,11 +209,11 @@ SBASTNodeTest >> testWrapInBlock [
 	self assert: block statements first statements first = selection
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 SBASTNodeTest >> testWrapInCascade [
 
 	| block selection |
-	block := '[5 squared]' parseAsSandblock.
+	block := self parse: '[5 squared]'.
 	selection := block statements first.
 	(self methodFor: block) select: selection.
 	selection wrapInCascade.
@@ -221,11 +221,11 @@ SBASTNodeTest >> testWrapInCascade [
 	self assert: block statements first messages first = selection
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 SBASTNodeTest >> testWrapInCascadeMessageParts [
 
 	| block selection editor |
-	block := '[5 yourself. 5 parse: 2]' parseAsSandblock.
+	block := self parse: '[5 yourself. 5 parse: 2]'.
 	selection := block statements first.
 	editor := self methodFor: block.
 	editor select: selection.
@@ -238,11 +238,11 @@ SBASTNodeTest >> testWrapInCascadeMessageParts [
 	self assert: block statements first messages second receiver isNil
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 SBASTNodeTest >> testWrapInCascadeMultiSelection [
 
 	| block selection editor |
-	block := '[5 squared. 5 + 2]' parseAsSandblock.
+	block := self parse: '[5 squared. 5 + 2]'.
 	selection := block statements first.
 	editor := self methodFor: block.
 	editor select: selection.
@@ -255,11 +255,11 @@ SBASTNodeTest >> testWrapInCascadeMultiSelection [
 	self assert: block statements first messages second receiver isNil
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 SBASTNodeTest >> testWrapInMessageSend [
 
 	| block selection |
-	block := '[5]' parseAsSandblock.
+	block := self parse: '[5]'.
 	selection := block statements first.
 	self methodFor: block.
 	selection grammarHandler
@@ -270,11 +270,11 @@ SBASTNodeTest >> testWrapInMessageSend [
 	self assert: block statements first receiver = selection
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 SBASTNodeTest >> testWrapInReturn [
 
 	| block selection |
-	block := '[5]' parseAsSandblock.
+	block := self parse: '[5]'.
 	self methodFor: block.
 	selection := block statements first.
 	selection performAction: #wrapInReturn.

--- a/packages/Sandblocks-Core/SBBlockTest.class.st
+++ b/packages/Sandblocks-Core/SBBlockTest.class.st
@@ -8,7 +8,7 @@ Class {
 SBBlockTest >> testLeftRotateBinaryMessages [
 
 	| block selection editor |
-	block := '[(a + b) * c]' parseAsSandblock.
+	block := self parse: '[(a + b) * c]'.
 	editor := self methodFor: block.
 	selection := block statements first receiver.
 	selection leftRotate.
@@ -23,7 +23,7 @@ SBBlockTest >> testLeftRotateBinaryMessages [
 SBBlockTest >> testRotateBlock [
 
 	| block selection editor |
-	block := '[a or: [b]]' parseAsSandblock.
+	block := self parse: '[a or: [b]]'.
 	editor := self methodFor: block.
 	selection := block statements first arguments first.
 	selection leftRotate.
@@ -38,7 +38,7 @@ SBBlockTest >> testRotateBlock [
 SBBlockTest >> testRotateKeywordMessage [
 
 	| block selection editor |
-	block := '[(a or: b) ifTrue: c]' parseAsSandblock.
+	block := self parse: '[(a or: b) ifTrue: c]'.
 	editor := self methodFor: block.
 	selection := block statements first receiver.
 	selection leftRotate.
@@ -53,7 +53,7 @@ SBBlockTest >> testRotateKeywordMessage [
 SBBlockTest >> testSwap [
 
 	| block selection n5 n3 |
-	block := '[5 squared: 3]' parseAsSandblock.
+	block := self parse: '[5 squared: 3]'.
 	self methodFor: block.
 	selection := block statements first.
 	n5 := selection receiver.

--- a/packages/Sandblocks-Core/SBClipboardTest.class.st
+++ b/packages/Sandblocks-Core/SBClipboardTest.class.st
@@ -25,7 +25,7 @@ SBClipboardTest >> tearDown [
 SBClipboardTest >> testCopyPasteBlock [
 
 	| block from to |
-	block := '[5. 6]' parseAsSandblock.
+	block := self parse: '[5. 6]'.
 	self methodFor: block.
 	from := block statements first.
 	to := block statements second.
@@ -41,7 +41,7 @@ SBClipboardTest >> testCopyPasteBlock [
 SBClipboardTest >> testCopyString [
 
 	| block from |
-	block := '[5 squared]' parseAsSandblock.
+	block := self parse: '[5 squared]'.
 	self methodFor: block.
 	from := block statements first.
 	
@@ -55,7 +55,7 @@ SBClipboardTest >> testCopyString [
 SBClipboardTest >> testPasteAfter [
 
 	| block selection editor |
-	block := '[a. b. c. self selected: 5]' parseAsSandblock.
+	block := self parse: '[a. b. c. self selected: 5]'.
 	selection := block statements last.
 	editor := self methodFor: block.
 	block statements first select.
@@ -71,7 +71,7 @@ SBClipboardTest >> testPasteAfter [
 SBClipboardTest >> testPasteMultiple [
 
 	| block selection editor |
-	block := '[a. b. c. self selected: 5]' parseAsSandblock.
+	block := self parse: '[a. b. c. self selected: 5]'.
 	selection := block statements last.
 	editor := self methodFor: block.
 	block statements first select.
@@ -89,7 +89,7 @@ SBClipboardTest >> testPasteMultiple [
 SBClipboardTest >> testPasteString [
 
 	| block from |
-	block := '[5]' parseAsSandblock.
+	block := self parse: '[5]'.
 	self methodFor: block.
 	from := block statements first.
 	
@@ -102,7 +102,7 @@ SBClipboardTest >> testPasteString [
 SBClipboardTest >> testPasteStringAfterCopyBlock [
 
 	| block from to |
-	block := '[5. 6]' parseAsSandblock.
+	block := self parse: '[5. 6]'.
 	self methodFor: block.
 	from := block statements first.
 	to := block statements second.

--- a/packages/Sandblocks-Core/SBInputDeleteTest.class.st
+++ b/packages/Sandblocks-Core/SBInputDeleteTest.class.st
@@ -8,7 +8,7 @@ Class {
 SBInputDeleteTest >> testDeleteInArray [
 
 	| block editor array |
-	block := '[{a. b}]' parseAsSandblock.
+	block := self parse: '[{a. b}]'.
 	editor := self methodFor: block.
 	
 	array := block statements first.
@@ -27,7 +27,7 @@ SBInputDeleteTest >> testDeleteInArray [
 SBInputDeleteTest >> testDeleteInBinaryExpression [
 
 	| block editor b |
-	block := '[a + b]' parseAsSandblock.
+	block := self parse: '[a + b]'.
 	editor := self methodFor: block.
 	
 	b := block statements first arguments first.
@@ -48,12 +48,12 @@ SBInputDeleteTest >> testDeleteInBinaryExpression [
 SBInputDeleteTest >> testDeleteInBlock [
 
 	| a block editor |
-	block := '[[a]]' parseAsSandblock.
+	block := self parse: '[[a]]'.
 	editor := self methodFor: block.
 	a := block statements first statements first.
 	
 	editor startInput: a at: 3 replacingContents: false.
-
+	
 	a deleteBeforeCursor.
 	block statements first statements first deleteBeforeCursor.
 	
@@ -66,7 +66,7 @@ SBInputDeleteTest >> testDeleteInEmptyString [
 
 	| block editor string |
 	string := SBStString new contents: ''.
-	block := '[]' parseAsSandblock.
+	block := self parse: '[]'.
 	editor := self methodFor: block.
 	block addMorphBack: string.
 	editor startInput: string at: 0 replacingContents: false.
@@ -80,7 +80,7 @@ SBInputDeleteTest >> testDeleteInEmptyString [
 SBInputDeleteTest >> testDeleteInNestedArray [
 
 	| block editor a |
-	block := '[self square: {a}]' parseAsSandblock.
+	block := self parse: '[self square: {a}]'.
 	editor := self methodFor: block.
 	
 	a := block statements first arguments first submorphs first.
@@ -98,7 +98,7 @@ SBInputDeleteTest >> testDeleteInNestedArray [
 SBInputDeleteTest >> testNestedSends [
 
 	| block |
-	block := '[a squared s]' parseAsSandblock.
+	block := self parse: '[a squared s]'.
 	self editorFor: block.
 	
 	block statements first messageParts first

--- a/packages/Sandblocks-Core/SBMessagePartTest.class.st
+++ b/packages/Sandblocks-Core/SBMessagePartTest.class.st
@@ -8,14 +8,14 @@ Class {
 SBMessagePartTest >> testAddColon [
 
 	| message |
-	message := '5 yourself' parseAsSandblock
+	message := self parse: '5 yourself'
 ]
 
 { #category : #'as yet unclassified' }
 SBMessagePartTest >> testBinaryMessageEdit [
 
 	| message editor |
-	message := '5 + 2' parseAsSandblock.
+	message := self parse: '5 + 2'.
 	editor := self methodFor: message.
 	editor startInput: message messageParts first at: 0 replacingContents: false.
 	message messageParts first keyStroke: (self keyboardEvent: $-).
@@ -31,7 +31,7 @@ SBMessagePartTest >> testBinaryMessageEdit [
 SBMessagePartTest >> testChangeDoesNothing [
 
 	| message |
-	message := '5 yourself' parseAsSandblock.
+	message := self parse: '5 yourself'.
 	self methodFor: message.
 	message messageParts first select.
 	message messageParts first changeToUnknown.
@@ -42,7 +42,7 @@ SBMessagePartTest >> testChangeDoesNothing [
 SBMessagePartTest >> testDeleteAround [
 
 	| block |
-	block := '[5 yourself: 2 send: 8]' parseAsSandblock.
+	block := self parse: '[5 yourself: 2 send: 8]'.
 	self methodFor: block.
 	
 	block statements first messageParts second deleteAround.
@@ -53,7 +53,7 @@ SBMessagePartTest >> testDeleteAround [
 SBMessagePartTest >> testHasColon [
 
 	| message |
-	message := '5 yourself' parseAsSandblock.
+	message := self parse: '5 yourself'.
 	message selector: 'yourself' arguments: #().
 	self deny: message messageParts first hasColon.
 	message selector: 'yourself:' arguments: {SBUnknown new}.
@@ -66,7 +66,7 @@ SBMessagePartTest >> testHasColon [
 SBMessagePartTest >> testInsertMessagePartAtEnd [
 
 	| message |
-	message := 'a do: b' parseAsSandblock.
+	message := self parse: 'a do: b'.
 	self methodFor: message.
 	message arguments last insertElementAfter.
 	self assert: message selector = 'do::'.
@@ -77,7 +77,7 @@ SBMessagePartTest >> testInsertMessagePartAtEnd [
 SBMessagePartTest >> testInsertMessagePartAtStart [
 
 	| message |
-	message := 'a do: b' parseAsSandblock.
+	message := self parse: 'a do: b'.
 	self methodFor: message.
 	
 	" noop "
@@ -92,10 +92,10 @@ SBMessagePartTest >> testInsertMessagePartAtStart [
 SBMessagePartTest >> testInsertMessagePartBeforeEnd [
 
 	| message |
-	message := 'a do: b' parseAsSandblock.
+	message := self parse: 'a do: b'.
 	self methodFor: message.
 	message arguments last insertElementAfter.
-	self assert:  'do::' equals: message selector.
+	self assert: 'do::' equals: message selector.
 	self assert: message arguments last isUnknown
 ]
 
@@ -103,7 +103,7 @@ SBMessagePartTest >> testInsertMessagePartBeforeEnd [
 SBMessagePartTest >> testPressColonInExistingMessage [
 
 	| message argument part |
-	message := '5 yourself: 2' parseAsSandblock.
+	message := self parse: '5 yourself: 2'.
 	part := message messageParts first.
 	argument := message arguments first.
 	(self methodFor: message) startInput: message at: 3 replacingContents: false.
@@ -138,8 +138,11 @@ SBMessagePartTest >> testTypeBinary [
 SBMessagePartTest >> testUseSuggestion [
 
 	| message editor |
-	message := '5 yourself' parseAsSandblock.
-	(editor := self methodFor: message) startInput: message at: 1 replacingContents: false.
+	message := self parse: '5 yourself'.
+	(editor := self methodFor: message)
+		startInput: message
+		at: 1
+		replacingContents: false.
 	message useSuggestion: 'yourself:'.
 	self assert: message arguments last isSelected.
 	self assert: message arguments first isUnknown.

--- a/packages/Sandblocks-Core/SBTest.class.st
+++ b/packages/Sandblocks-Core/SBTest.class.st
@@ -76,49 +76,58 @@ SBTest class >> mouseEventAt: aPoint shift: aBoolean command: anotherBoolean con
 		hand: ActiveHand
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #asserting }
 SBTest >> assert: anObject structure: aCollection [
 
 	aCollection do: [:assoc | self assert: assoc value equals: (anObject perform: assoc key)]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #support }
 SBTest >> editorFor: aBlock [
 
 	^ self class editorFor: aBlock
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'support - events' }
 SBTest >> keyboardEvent: aCharacter [
 
 	^ self class keyboardEvent: aCharacter
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'support - events' }
 SBTest >> keyboardEvent: aCharacter shift: aBoolean command: anotherBoolean [
 
 	^ self class keyboardEvent: aCharacter shift: aBoolean command: anotherBoolean
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'support - events' }
 SBTest >> keyboardEvent: aCharacter shift: aBoolean command: anotherBoolean control: aThirdBoolean [
 
 	^ self class keyboardEvent: aCharacter shift: aBoolean command: anotherBoolean control: aThirdBoolean
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #support }
 SBTest >> methodFor: aBlock [
 
 	^ self class methodFor: aBlock
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #support }
+SBTest >> parse: aString [
+
+	^ [aString parseAsSandblock] on: UndeclaredVariableWarning do: [:ex |
+		ex resume.
+		
+		]
+]
+
+{ #category : #'support - events' }
 SBTest >> send: anEvent to: anEditor [
 
 	anEvent becomeActiveDuring: [anEditor filterEvent: anEvent for: nil]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'support - events' }
 SBTest >> tick [
 
 	World doOneCycle


### PR DESCRIPTION
This is necessary to complement SUnit-ct.130, which treats unhandled warnings as a failure of the test case. Note that there are still some other things to do at the moment:

* This particular exception is weird at all - a warning should not "do nothing" in its defaultAction, so maybe the superclass of this exception should be changed instead
* smalltalkCI has not yet been told about the new semantics of warnings in tests (I'm on it).

Given these points, I'm parking this patch here for now until the above points have been resolved ...

Depends on #92.