### PR TITLE
SBStTestCase: Update history and honor expected failures

### DIFF
--- a/packages/Sandblocks-Babylonian/SBStTestCase.class.st
+++ b/packages/Sandblocks-Babylonian/SBStTestCase.class.st
@@ -232,32 +232,47 @@ SBStTestCase >> reportError: anError [
 		ifNotNil: [:context | (self blockForPC: context previousPc) attachDecorator: (errorIndicator := SBErrorDecorator new message: anError asString)]"
 ]
 
+{ #category : #errors }
+SBStTestCase >> reportPass [
+
+	passIcon
+		changeIconName: #iconCheck;
+		color: (Color r: 0.8 g: 1 b: 0.6).
+	reportedError ifNotNil: #delete.
+	reportedError := self sandblockEditor reportError: nil process: nil source: self
+]
+
 { #category : #actions }
 SBStTestCase >> runTest [
 	<action>
 
+	| case result |
 	SBExecutionEnvironment value: self during: [
 		self sendStartNotification.
-	
+		
 		self clearErrors.
 		passIcon
-			changeIconName: #'iconClockO';
-			color: Color yellow.
-		([(self methodClass selector: self currentSelector) runCase. true]
+			changeIconName: #iconClockO;
+			color: (Color r: 1 g: 1 b: 0.0).
+		case := self methodClass selector: self currentSelector.
+		result := TestResult new.
+		([
+			case runCase.
+			true]
 			on: TestResult failure
 			do: [:err |
+				result sandblocksAddFailure: case.
 				self reportError: err.
 				err return: false]
 			on: TestResult exError
 			do: [:err |
+				result sandblocksAddError: case.
 				self reportError: err.
 				err return: false]) ifTrue: [
-			passIcon
-				changeIconName: #iconCheck;
-				color: Color lightGreen.
-			reportedError ifNotNil: #delete.
-			reportedError := nil].
-	
+			result sandblocksAddPass: case.
+			self reportPass].
+		(result respondsTo: #dispatchResultsIntoHistory) ifTrue: [result dispatchResultsIntoHistory].
+		
 		self sendFinishNotification.
 		SBExecutionEnvironment value: nil]
 ]

--- a/packages/Sandblocks-Babylonian/SBStTestCase.class.st
+++ b/packages/Sandblocks-Babylonian/SBStTestCase.class.st
@@ -5,6 +5,7 @@ Class {
 		'selectorInput',
 		'errorIndicator',
 		'passIcon',
+		'passNote',
 		'reportedError',
 		'autoRun'
 	],
@@ -151,6 +152,7 @@ SBStTestCase >> initialize [
 				color: (Color r: 1 g: 1 b: 1);
 				on: #click send: #openError to: self;
 				yourself);
+			addMorphBack: (passNote := SBStringMorph new contents: '');
 			addMorphBack: (Morph new
 				width: 6;
 				height: 0;
@@ -220,6 +222,7 @@ SBStTestCase >> reportError: anError [
 	passIcon
 		changeIconName: #iconRemove;
 		color: (Color r: 1 g: 0.0 b: 0.0).
+	passNote contents: (self shouldPass ifFalse: ['(expected failure)'] ifTrue: ['']).
 	
 	reportedError ifNotNil: #delete.
 	reportedError := self sandblockEditor
@@ -238,6 +241,8 @@ SBStTestCase >> reportPass [
 	passIcon
 		changeIconName: #iconCheck;
 		color: (Color r: 0.8 g: 1 b: 0.6).
+	passNote contents: (self shouldPass ifFalse: ['(unexpected pass)'] ifTrue: ['']).
+	
 	reportedError ifNotNil: #delete.
 	reportedError := self sandblockEditor reportError: nil process: nil source: self
 ]
@@ -302,6 +307,12 @@ SBStTestCase >> sendStopNotification [
 
 	self sandblockEditor allMorphsDo: [:morph |
 		(morph isSandblock and: [morph listensToExamples]) ifTrue: [morph exampleStopped: self]]
+]
+
+{ #category : #testing }
+SBStTestCase >> shouldPass [
+
+	^ (self methodClass selector: self currentSelector) shouldPass
 ]
 
 { #category : #'method protocol' }

--- a/packages/Sandblocks-Babylonian/TestResult.extension.st
+++ b/packages/Sandblocks-Babylonian/TestResult.extension.st
@@ -1,0 +1,19 @@
+Extension { #name : #TestResult }
+
+{ #category : #'*Sandblocks-Babylonian-accessing' }
+TestResult >> sandblocksAddError: aTestCase [
+
+	^ errors add: aTestCase
+]
+
+{ #category : #'*Sandblocks-Babylonian-accessing' }
+TestResult >> sandblocksAddFailure: aTestCase [
+
+	^ failures add: aTestCase
+]
+
+{ #category : #'*Sandblocks-Babylonian-accessing' }
+TestResult >> sandblocksAddPass: aTestCase [
+
+	^ passed add: aTestCase
+]

--- a/packages/Sandblocks-Core/SBBrowserEditor.class.st
+++ b/packages/Sandblocks-Core/SBBrowserEditor.class.st
@@ -162,6 +162,15 @@ SBBrowserEditor >> openOnlyMorph: aBlock [
 	self openMorph: aBlock
 ]
 
+{ #category : #'as yet unclassified' }
+SBBrowserEditor >> reportError: anError process: aProcess source: anExecutableEnvironment [
+
+	| result |
+	result := super reportError: anError process: aProcess source: anExecutableEnvironment.
+	self model changed: #messageList.
+	^ result
+]
+
 { #category : #artefacts }
 SBBrowserEditor >> save: anArtefact tryFixing: aFixBoolean quick: aQuickBoolean [
 

--- a/packages/Sandblocks-Core/SBClipboardTest.class.st
+++ b/packages/Sandblocks-Core/SBClipboardTest.class.st
@@ -7,21 +7,20 @@ Class {
 	#category : #'Sandblocks-Core-Tests'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #running }
 SBClipboardTest >> setUp [
 
 	super setUp.
 	oldClipboard := Clipboard clipboardText
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #running }
 SBClipboardTest >> tearDown [
 
-	super tearDown.
-	Clipboard clipboardText: oldClipboard
+	[oldClipboard ifNotNil: [Clipboard clipboardText: oldClipboard]] ensure: super tearDown
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 SBClipboardTest >> testCopyPasteBlock [
 
 	| block from to |
@@ -37,7 +36,7 @@ SBClipboardTest >> testCopyPasteBlock [
 	self assert: '5' equals: block statements second contents
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 SBClipboardTest >> testCopyString [
 
 	| block from |
@@ -51,7 +50,7 @@ SBClipboardTest >> testCopyString [
 	self assert: '5 squared' equals: Clipboard clipboardText string
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 SBClipboardTest >> testPasteAfter [
 
 	| block selection editor |
@@ -67,7 +66,7 @@ SBClipboardTest >> testPasteAfter [
 	self assert: 'c' equals: block statements seventh contents
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 SBClipboardTest >> testPasteMultiple [
 
 	| block selection editor |
@@ -89,7 +88,7 @@ SBClipboardTest >> testPasteMultiple [
 	self assert: 'c' equals: block statements seventh contents
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 SBClipboardTest >> testPasteString [
 
 	| block from |
@@ -102,7 +101,7 @@ SBClipboardTest >> testPasteString [
 	self assert: '6' equals: block statements first contents
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 SBClipboardTest >> testPasteStringAfterCopyBlock [
 
 	| block from to |

--- a/packages/Sandblocks-Core/SBEditor.class.st
+++ b/packages/Sandblocks-Core/SBEditor.class.st
@@ -1338,7 +1338,9 @@ SBEditor >> replaceInput: aMorph [
 { #category : #'as yet unclassified' }
 SBEditor >> reportError: anError process: aProcess source: anExecutableEnvironment [
 
-	^ errors ifNotNil: [errors addError: anError process: aProcess source: anExecutableEnvironment]
+	anError ifNil: [^ nil].
+	errors ifNil: [^ nil].
+	^ errors addError: anError process: aProcess source: anExecutableEnvironment
 ]
 
 { #category : #errors }


### PR DESCRIPTION
## [babylonian/core: dispatch SBStTestCase results into history](https://github.com/hpi-swa/sandblocks/commit/7faf6ab82aacabaf0f43252114ddbd73c278f0ae) (7faf6ab82aacabaf0f43252114ddbd73c278f0ae)

This change is visible when you run an SBStTestCase from a browser editor. In the past, the test result icon in the containing browser's message list would not have been updated (as compared to running the same test via the message list menu > "run test") - now this works. See also: `CodeHolder>>#testRunSuite:`.

![sandblocks-test-update-history](https://user-images.githubusercontent.com/38782922/156444558-e94acf62-2f75-42b7-aa1f-1d0b38e87644.gif)

## [babylonian: indicate expected failures and unexpected passes for tests](https://github.com/hpi-swa/sandblocks/commit/4d9f569b4bf8f42b697946b5e87c1ba009f03e2c) (4d9f569b4bf8f42b697946b5e87c1ba009f03e2c)

![image](https://user-images.githubusercontent.com/38782922/156444723-f0a49597-c499-47ae-a495-15e76f4a924e.png)

⚠️ Please report back whether you like this display. An alternative would be compound icons (such as <kbd>✔️⚠️</kbd> or <kbd>❌✔️</kbd>) with an explaining tool tip. I'm not sure what gives the best UX.

## [core: robustize clipboard test #tearDown against previously empty clipboard](https://github.com/hpi-swa/sandblocks/commit/608a6d257f11a3f577d33f3d4e926e88b865480b)

Nit.