### PR TITLE
st: add suggestions for class variables

### DIFF
--- a/packages/Sandblocks-Core/SBColorPolicy.class.st
+++ b/packages/Sandblocks-Core/SBColorPolicy.class.st
@@ -270,6 +270,12 @@ SBColorPolicy >> symbolsForCharacter: aBlock [
 ]
 
 { #category : #'as yet unclassified' }
+SBColorPolicy >> symbolsForClassVariableDeclaration: aBlock [
+
+	^ #(nil nil)
+]
+
+{ #category : #'as yet unclassified' }
 SBColorPolicy >> symbolsForComment: aBlock [
 
 	^ #('" ' ' "')

--- a/packages/Sandblocks-Smalltalk/SBStBasicMethod.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStBasicMethod.class.st
@@ -171,6 +171,22 @@ SBStBasicMethod >> changeToUnknown [
 ]
 
 { #category : #accessing }
+SBStBasicMethod >> classVariables [
+
+	| editor |
+	editor := self sandblockEditor.
+	^ Array streamContents: [:stream |
+		self methodClass withAllSuperclassesDo: [:class | | open |
+			open := [class classVarNames collect: [:name | SBStName classVariable: name class: class]].
+			stream nextPutAll: (SBToggledCode comment: '' active: 1 do: {
+				[open value].
+				[
+					editor
+						ifNil: open
+						ifNotNil: [editor blockFor: class withInterfaces: #(#isEditor) ifOpen: [:c | c classVariables] ifClosed: open]]})]]
+]
+
+{ #category : #accessing }
 SBStBasicMethod >> collapsed: aBoolean [
 
 	self body visible not = aBoolean ifTrue: [^ self].
@@ -257,14 +273,21 @@ SBStBasicMethod >> currentSelector: aString [
 { #category : #accessing }
 SBStBasicMethod >> declarations [
 
-	^ self arguments, self instanceVariables
+	^ Array streamContents: [:stream |
+		self declarationsDo: [:declaration |
+			stream nextPut: declaration.
+			
+			].
+		
+		]
 ]
 
 { #category : #accessing }
 SBStBasicMethod >> declarationsDo: aBlock [
 
 	self arguments do: aBlock.
-	self instanceVariables do: aBlock
+	self instanceVariables do: aBlock.
+	self classVariables do: aBlock
 ]
 
 { #category : #actions }

--- a/packages/Sandblocks-Smalltalk/SBStDeclarationForBehaviorVariable.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStDeclarationForBehaviorVariable.class.st
@@ -1,0 +1,106 @@
+Class {
+	#name : #SBStDeclarationForBehaviorVariable,
+	#superclass : #SBStDeclarationBehavior,
+	#instVars : [
+		'class'
+	],
+	#category : #'Sandblocks-Smalltalk'
+}
+
+{ #category : #accessing }
+SBStDeclarationForBehaviorVariable >> allVariableNames [
+
+	^ self subclassResponsibility
+]
+
+{ #category : #converting }
+SBStDeclarationForBehaviorVariable >> asSuggestionItem [
+
+	^ SBSuggestionItem selector: self contents label: self typeLabel
+]
+
+{ #category : #accessing }
+SBStDeclarationForBehaviorVariable >> class: aClass [
+
+	class := aClass
+]
+
+{ #category : #actions }
+SBStDeclarationForBehaviorVariable >> createGetterSetter [
+	<action>
+
+	self block sandblockEditor
+		createArtefactInView: self getterBlock;
+		createArtefactInView: self setterBlock
+]
+
+{ #category : #private }
+SBStDeclarationForBehaviorVariable >> getterBlock [
+
+	^ SBStMethod new
+		selector: self contents asSymbol
+			arguments: #()
+			class: self block containingArtefact shownClass;
+		body: (SBStBlockBody new statements: {SBStReturn new expression: (SBStName contents: self contents)})
+]
+
+{ #category : #accessing }
+SBStDeclarationForBehaviorVariable >> guessedClass [
+
+	^ nil
+]
+
+{ #category : #printing }
+SBStDeclarationForBehaviorVariable >> printBlockOn: aStream [
+
+	aStream
+		nextPutAll: self typeLabel;
+		space;
+		nextPutAll: self contents
+]
+
+{ #category : #accessing }
+SBStDeclarationForBehaviorVariable >> relatedClass [
+
+	^ class ifNil: [self block containingArtefact relatedClass]
+]
+
+{ #category : #accessing }
+SBStDeclarationForBehaviorVariable >> scope [
+
+	^ self block sandblockEditor
+		ifNotNil: [:e | e methods select: [:m | m methodClass = self block containingArtefact shownClass]]
+		ifNil: [#()]
+]
+
+{ #category : #private }
+SBStDeclarationForBehaviorVariable >> setterBlock [
+
+	| argumentName |
+	argumentName := self setterBlockArgumentName.
+	^ SBStMethod new
+		selector: self contents asSymbol asSimpleSetter
+			arguments: {SBStName contents: argumentName}
+			class: self block containingArtefact shownClass;
+		body: (SBStBlockBody new statements: {[:b | b assign: self contents to: (b name: argumentName)] sbStBuild})
+]
+
+{ #category : #private }
+SBStDeclarationForBehaviorVariable >> setterBlockArgumentName [
+
+	| className |
+	className := (self guessedClass ifNil: [Object]) canonicalArgumentName.
+	^ (className first isVowel ifTrue: ['an'] ifFalse: ['a']), className
+]
+
+{ #category : #accessing }
+SBStDeclarationForBehaviorVariable >> typeLabel [
+
+	^ self subclassResponsibility
+]
+
+{ #category : #testing }
+SBStDeclarationForBehaviorVariable >> valid [
+
+	^ self allVariableNames includes: self contents
+]

--- a/packages/Sandblocks-Smalltalk/SBStDeclarationForClassVariable.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStDeclarationForClassVariable.class.st
@@ -1,0 +1,54 @@
+Class {
+	#name : #SBStDeclarationForClassVariable,
+	#superclass : #SBStDeclarationForBehaviorVariable,
+	#category : #'Sandblocks-Smalltalk'
+}
+
+{ #category : #'as yet unclassified' }
+SBStDeclarationForClassVariable class >> checkCastFor: aBlock parent: aMorph [
+
+	| artefact |
+	artefact := aMorph containingSandblock containingArtefact.
+	^ (artefact satisfies: {#notNil. #isEditor. #isClassContainer}) and: [aMorph = artefact classVariables]
+]
+
+{ #category : #accessing }
+SBStDeclarationForClassVariable >> allVariableNames [
+
+	^ self block containingArtefact object classVarNames
+]
+
+{ #category : #actions }
+SBStDeclarationForClassVariable >> browse [
+	<action>
+
+	self systemNavigation
+		browseAllCallsOn: self contents
+		from: self block containingArtefact shownClass
+]
+
+{ #category : #actions }
+SBStDeclarationForClassVariable >> browseReferences [
+
+	self systemNavigation
+		browseAllCallsOn: self contents
+		from: self relatedClass object
+]
+
+{ #category : #accessing }
+SBStDeclarationForClassVariable >> guessedClass [
+
+	^ self block binding value ifNotNil: #class
+]
+
+{ #category : #accessing }
+SBStDeclarationForClassVariable >> symbolsFor: aColorPolicy [
+
+	^ aColorPolicy symbolsForClassVariableDeclaration: self block
+]
+
+{ #category : #accessing }
+SBStDeclarationForClassVariable >> typeLabel [
+
+	^ 'class variable'
+]

--- a/packages/Sandblocks-Smalltalk/SBStDeclarationForInstanceVariable.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStDeclarationForInstanceVariable.class.st
@@ -1,9 +1,6 @@
 Class {
 	#name : #SBStDeclarationForInstanceVariable,
-	#superclass : #SBStDeclarationBehavior,
-	#instVars : [
-		'class'
-	],
+	#superclass : #SBStDeclarationForBehaviorVariable,
 	#category : #'Sandblocks-Smalltalk'
 }
 
@@ -15,20 +12,20 @@ SBStDeclarationForInstanceVariable class >> checkCastFor: aBlock parent: aMorph 
 	^ (artefact satisfies: {#notNil. #isEditor. #isClassContainer}) and: [aMorph = artefact instanceVariables]
 ]
 
-{ #category : #'as yet unclassified' }
-SBStDeclarationForInstanceVariable >> asSuggestionItem [
+{ #category : #accessing }
+SBStDeclarationForInstanceVariable >> allVariableNames [
 
-	^ SBSuggestionItem selector: self contents label: 'instance variable'
+	^ self block containingArtefact object instVarNames
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #actions }
 SBStDeclarationForInstanceVariable >> browse [
 	<action>
 
 	self systemNavigation browseAllAccessesTo: self contents from: self block containingArtefact shownClass
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #actions }
 SBStDeclarationForInstanceVariable >> browseReferences [
 
 	self systemNavigation
@@ -36,73 +33,21 @@ SBStDeclarationForInstanceVariable >> browseReferences [
 		from: self relatedClass object
 ]
 
-{ #category : #'as yet unclassified' }
-SBStDeclarationForInstanceVariable >> class: aClass [
-
-	class := aClass
-]
-
-{ #category : #'as yet unclassified' }
-SBStDeclarationForInstanceVariable >> createGetterSetter [
-	<action>
-
-	self block sandblockEditor
-		createArtefactInView: self getterBlock;
-		createArtefactInView: self setterBlock
-]
-
-{ #category : #'as yet unclassified' }
-SBStDeclarationForInstanceVariable >> getterBlock [
-
-	^ SBStMethod new
-		selector: self contents asSymbol
-			arguments: #()
-			class: self block containingArtefact shownClass;
-		body: (SBStBlockBody new statements: {SBStReturn new expression: (SBStName contents: self contents)})
-]
-
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBStDeclarationForInstanceVariable >> guessedClass [
 
-	^ nil
+	class isMeta ifTrue: [^ (class theNonMetaClass instVarNamed: self contents) class].
+	^ super guessedClass
 ]
 
-{ #category : #'as yet unclassified' }
-SBStDeclarationForInstanceVariable >> printBlockOn: aStream [
-
-	aStream nextPutAll: 'instance variable '; nextPutAll: self contents
-]
-
-{ #category : #'as yet unclassified' }
-SBStDeclarationForInstanceVariable >> relatedClass [
-
-	^ class ifNil: [self block containingArtefact relatedClass]
-]
-
-{ #category : #'as yet unclassified' }
-SBStDeclarationForInstanceVariable >> scope [
-
-	^ self block sandblockEditor ifNotNil: [:e | e methods select: [:m | m methodClass = self block containingArtefact shownClass]] ifNil: [#()]
-]
-
-{ #category : #'as yet unclassified' }
-SBStDeclarationForInstanceVariable >> setterBlock [
-
-	^ SBStMethod new
-		selector: self contents asSymbol asSimpleSetter
-			arguments: {SBStName contents: 'anObject'}
-			class: self block containingArtefact shownClass;
-		body: (SBStBlockBody new statements: {[:b | b assign: self contents to: (b name: 'anObject')] sbStBuild})
-]
-
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBStDeclarationForInstanceVariable >> symbolsFor: aColorPolicy [
 
 	^ aColorPolicy symbolsForInstanceVariableDeclaration: self block
 ]
 
-{ #category : #'as yet unclassified' }
-SBStDeclarationForInstanceVariable >> valid [
+{ #category : #accessing }
+SBStDeclarationForInstanceVariable >> typeLabel [
 
-	^ self block containingArtefact object instVarNames includes: self contents
+	^ 'instance variable'
 ]

--- a/packages/Sandblocks-Smalltalk/SBStName.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStName.class.st
@@ -10,6 +10,14 @@ Class {
 }
 
 { #category : #'as yet unclassified' }
+SBStName class >> classVariable: aString class: aClass [
+
+	^ (self contents: aString)
+		behavior: (SBStDeclarationForClassVariable new class: aClass);
+		yourself
+]
+
+{ #category : #'as yet unclassified' }
 SBStName class >> contents: aString [
 
 	^ self new contents: aString; yourself

--- a/packages/Sandblocks-Smalltalk/SBStNameBehavior.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStNameBehavior.class.st
@@ -171,6 +171,24 @@ SBStNameBehavior >> fixActionsForUppercaseBinding [
 ]
 
 { #category : #'as yet unclassified' }
+SBStNameBehavior >> globalSuggestions [
+
+	^ Array streamContents: [:stream |
+		Smalltalk globals keysAndValuesDo: [:key :value |
+			(key sandblockMatch: self contents) ifTrue: [
+				stream nextPut: (SBSuggestionItem selector: key label: ((value isBehavior and: [key == value name])
+					ifTrue: ['class']
+					ifFalse: ['global']))]].
+		SBStSubstitution allSubclassesDo: [:class |
+			(class name sandblockMatch: self contents) ifTrue: [
+				class suggestion ifNotNil: [:block |
+					stream nextPut: ((SBProjectionSuggestionItem selector: class name label: 'projection')
+						completionAction: block;
+						instanceSuggestion: class instanceSuggestion
+							editor: self block sandblockEditor)]]]]
+]
+
+{ #category : #'as yet unclassified' }
 SBStNameBehavior >> guessedClass [
 
 	^ self block binding ifNotNil: [:b | b value class]
@@ -243,7 +261,7 @@ SBStNameBehavior >> isTemporaryVariable [
 ]
 
 { #category : #'as yet unclassified' }
-SBStNameBehavior >> lowercaseSuggestions [
+SBStNameBehavior >> localSuggestions [
 
 	^ Array streamContents: [:stream | self block scopesDo: [:scope | scope declarationsDo: [:decl | (decl contents sandblockMatch: self contents) ifTrue: [stream nextPut: decl asSuggestionItem]]]]
 ]
@@ -276,10 +294,13 @@ SBStNameBehavior >> resolveBinding [
 SBStNameBehavior >> suggestions [
 
 	| suggestions |
-	suggestions := self contents ifEmpty: [#()] ifNotEmpty: [:text |
-		text first isUppercase
-			ifTrue: [self uppercaseSuggestions]
-			ifFalse: [self lowercaseSuggestions]].
+	suggestions := self contents ifEmpty: [#()] ifNotEmpty: [
+		Array streamContents: [:stream |
+			stream
+				nextPutAll: self localSuggestions;
+				nextPutAll: self globalSuggestions.
+			
+			]].
 	^ suggestions sort: #selectorSize ascending
 ]
 
@@ -287,26 +308,6 @@ SBStNameBehavior >> suggestions [
 SBStNameBehavior >> symbolsFor: aColorPolicy [
 
 	^ self subclassResponsibility
-]
-
-{ #category : #'as yet unclassified' }
-SBStNameBehavior >> uppercaseSuggestions [
-
-	self flag: #todo.
-	"pool dict etc"
-	^ Array streamContents: [:stream |
-		Smalltalk globals keysAndValuesDo: [:key :value |
-			(key sandblockMatch: self contents) ifTrue: [
-				stream nextPut: (SBSuggestionItem selector: key label: ((value isBehavior and: [key == value name])
-					ifTrue: ['class']
-					ifFalse: ['global']))]].
-		SBStSubstitution allSubclassesDo: [:class |
-			(class name sandblockMatch: self contents) ifTrue: [
-				class suggestion ifNotNil: [:block |
-					stream nextPut: ((SBProjectionSuggestionItem selector: class name label: 'projection')
-						completionAction: block;
-						instanceSuggestion: class instanceSuggestion
-							editor: self block sandblockEditor)]]]]
 ]
 
 { #category : #'as yet unclassified' }


### PR DESCRIPTION
## [st: add suggestions for class variables](https://github.com/hpi-swa/sandblocks/commit/d1158596d2ec64d3cf3c4c8dd3f8dc870a85c43b) (d1158596d2ec64d3cf3c4c8dd3f8dc870a85c43b)

- `SBStNameBehavior>>suggestions`: Do not distinguish between syntactical casing (lowercase/uppercase) of the suggestions but rather between their origin (local/global), since class vars are actually scoped locally
- new sibling class `SBStDeclarationForClassVariable` of `SBStDeclarationForInstanceVariable` with common features extracted into new superclass `SBStDeclarationForBehaviorVariable`
- improved type guessing for class variables and instance variables of singleton (class objects)

![image](https://user-images.githubusercontent.com/38782922/156472326-743f4f3a-baad-41a3-b402-eb0e0660792e.png)
