### PR TITLE
st: fix use of Morph property protocol

### DIFF
--- a/packages/Sandblocks-Smalltalk/.squot-contents
+++ b/packages/Sandblocks-Smalltalk/.squot-contents
@@ -1,5 +1,6 @@
 SquotTrackedObjectMetadata {
 	#objectClassName : #PackageInfo,
+	#id : UUID [ 'aaf2f13dfd4d9948b37b6587b2dc6566' ],
 	#objectsReplacedByNames : true,
 	#serializer : #SquotTonelSerializer
 }

--- a/packages/Sandblocks-Smalltalk/SBStBasicMethod.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStBasicMethod.class.st
@@ -304,7 +304,7 @@ SBStBasicMethod >> exists [
 { #category : #accessing }
 SBStBasicMethod >> externalModification: aBoolean [
 
-	^ self setProperty: #externalModificationFlag toValue: aBoolean
+	self setProperty: #externalModificationFlag toValue: aBoolean
 ]
 
 { #category : #accessing }

--- a/packages/Sandblocks-Smalltalk/SBToggledCode.class.st
+++ b/packages/Sandblocks-Smalltalk/SBToggledCode.class.st
@@ -103,7 +103,8 @@ SBToggledCode >> buildRowFor: aBlock active: aBoolean [
 			yourself);
 		addMorphBack: (aBlock
 			setProperty: #previousBlockColor
-			toValue: (aBlock valueOfProperty: #sandblockBlockColor ifAbsent: [Color random])).
+				toValue: (aBlock valueOfProperty: #sandblockBlockColor ifAbsent: [Color random]);
+			yourself).
 	^ row
 ]
 


### PR DESCRIPTION
Since Morphic-ct.1906 (Trunk), `#setProperty:[...]` and `#removeProperty:` answer the property value instead of the receiver. In `SBToggledCode`, this led to an actual DNU. I quickly skimmed all other senders of both selectors and Sandblocks and did not identify any third violation.