### PR TITLE
debugger: fix debugging of examples

### DIFF
--- a/packages/Sandblocks-Debugger/.squot-contents
+++ b/packages/Sandblocks-Debugger/.squot-contents
@@ -1,5 +1,6 @@
 SquotTrackedObjectMetadata {
 	#objectClassName : #PackageInfo,
+	#id : UUID [ 'e9c8b9b42c1b3b43acdbfb62f45bcd84' ],
 	#objectsReplacedByNames : true,
 	#serializer : #SquotTonelSerializer
 }

--- a/packages/Sandblocks-Debugger/SBSmallError.class.st
+++ b/packages/Sandblocks-Debugger/SBSmallError.class.st
@@ -61,6 +61,12 @@ SBSmallError >> expanded [
 ]
 
 { #category : #'as yet unclassified' }
+SBSmallError >> focus [
+
+	
+]
+
+{ #category : #'as yet unclassified' }
 SBSmallError >> handlesMouseOver: anEvent [
 
 	^ true


### PR DESCRIPTION
Previously, invocating the action `#debug` on an `SBExample` failed because `SBSmallError` did not understand `#focus`.