### PR TITLE
Introduce Variants

### DIFF
--- a/packages/Sandblocks-Core/SBNamedBlock.class.st
+++ b/packages/Sandblocks-Core/SBNamedBlock.class.st
@@ -13,7 +13,7 @@ SBNamedBlock class >> block: aSBBlock named: aString [
 
 	^ self new
 		block: aSBBlock;
-		named: aString
+		name: aString
 ]
 
 { #category : #'as yet unclassified' }

--- a/packages/Sandblocks-Core/SBNamedBlock.class.st
+++ b/packages/Sandblocks-Core/SBNamedBlock.class.st
@@ -33,7 +33,7 @@ SBNamedBlock >> initialize [
 
 	super initialize.
 	
-	self name: 'A Tab'.
+	self name: 'A Block'.
 	self block: (SBLabel new contents: 'Some Content').
 ]
 

--- a/packages/Sandblocks-Core/SBNamedBlock.class.st
+++ b/packages/Sandblocks-Core/SBNamedBlock.class.st
@@ -1,0 +1,50 @@
+Class {
+	#name : #SBNamedBlock,
+	#superclass : #SBBlock,
+	#instVars : [
+		'name',
+		'block'
+	],
+	#category : #'Sandblocks-Core'
+}
+
+{ #category : #'as yet unclassified' }
+SBNamedBlock class >> block: aSBBlock named: aString [
+
+	^ self new
+		block: aSBBlock;
+		named: aString
+]
+
+{ #category : #'as yet unclassified' }
+SBNamedBlock >> block [
+
+	^ block
+]
+
+{ #category : #'as yet unclassified' }
+SBNamedBlock >> block: aSBBlock [
+
+	block := aSBBlock
+]
+
+{ #category : #'as yet unclassified' }
+SBNamedBlock >> initialize [
+
+	super initialize.
+	
+	self name: 'A Tab'.
+	self block: (SBLabel new contents: 'Some Content').
+]
+
+{ #category : #'as yet unclassified' }
+SBNamedBlock >> name [
+
+	^ name
+]
+
+{ #category : #'as yet unclassified' }
+SBNamedBlock >> name: aString [
+
+	name := aString
+]

--- a/packages/Sandblocks-Core/SBNamedBlock.class.st
+++ b/packages/Sandblocks-Core/SBNamedBlock.class.st
@@ -8,7 +8,7 @@ Class {
 	#category : #'Sandblocks-Core'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #'instance creation' }
 SBNamedBlock class >> block: aSBBlock named: aString [
 
 	^ self new
@@ -16,19 +16,19 @@ SBNamedBlock class >> block: aSBBlock named: aString [
 		name: aString
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBNamedBlock >> block [
 
 	^ block
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBNamedBlock >> block: aSBBlock [
 
 	block := aSBBlock
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #initialization }
 SBNamedBlock >> initialize [
 
 	super initialize.
@@ -37,13 +37,13 @@ SBNamedBlock >> initialize [
 	self block: (SBLabel new contents: 'Some Content').
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBNamedBlock >> name [
 
 	^ name
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBNamedBlock >> name: aString [
 
 	name := aString

--- a/packages/Sandblocks-Core/SBTextBubble.class.st
+++ b/packages/Sandblocks-Core/SBTextBubble.class.st
@@ -50,6 +50,14 @@ SBTextBubble >> changeToUnknown [
 ]
 
 { #category : #'as yet unclassified' }
+SBTextBubble >> click: anEvent [
+
+	super click: anEvent.
+	
+	self triggerEvent: #clicked
+]
+
+{ #category : #'as yet unclassified' }
 SBTextBubble >> colorAlpha: aNumber [
 
 	text colorAlpha: aNumber

--- a/packages/Sandblocks-Core/SBUnwrapConsecutiveCommand.class.st
+++ b/packages/Sandblocks-Core/SBUnwrapConsecutiveCommand.class.st
@@ -12,7 +12,7 @@ Class {
 { #category : #'as yet unclassified' }
 SBUnwrapConsecutiveCommand >> do [
 
-	unwrapped := target childSandblocks.
+	unwrapped ifNil: [unwrapped := target childSandblocks].
 	oldPositions := unwrapped collect: [:m | {m owner. m submorphIndex}].
 	
 	target owner addAllMorphs: unwrapped after: target.
@@ -40,4 +40,10 @@ SBUnwrapConsecutiveCommand >> undo [
 		with: unwrapped
 		do: [:pos :morph | pos first addMorph: morph asElementNumber: pos second].
 	^ target
+]
+
+{ #category : #'as yet unclassified' }
+SBUnwrapConsecutiveCommand >> unwrapped: aCollectionOfBlocks [
+
+	unwrapped := aCollectionOfBlocks
 ]

--- a/packages/Sandblocks-Core/SBVimInputMapping.class.st
+++ b/packages/Sandblocks-Core/SBVimInputMapping.class.st
@@ -151,6 +151,7 @@ SBVimInputMapping >> registerDefaultShortcuts [
 
 		" smalltalk "
 		cmdShortcut: $" do: #wrapInToggledCode;
+		cmdShortcut: $Q do: #wrapInVariant;
 		cmdShortcut: $D do: #insertLabelAbove;
 		cmdShortcut: $b do: #insertHaltBelow;
 		cmdShortcut: $B do: #insertHaltAbove;

--- a/packages/Sandblocks-Morphs/SBButton.class.st
+++ b/packages/Sandblocks-Morphs/SBButton.class.st
@@ -232,7 +232,7 @@ SBButton >> makeSmall [
 	| widget |
 	self
 		cellGap: 4.0 sbScaled;
-		layoutInset: (6.0 @ 4.0) sbScaled.
+		layoutInset: (4.0 @ 2.0) sbScaled.
 	
 	widget := self widgetMorph.
 	widget ifNotNil: [

--- a/packages/Sandblocks-Morphs/SBButton.class.st
+++ b/packages/Sandblocks-Morphs/SBButton.class.st
@@ -226,6 +226,24 @@ SBButton >> label: aString shortcut: aShortcut do: aBlock [
 		do: aBlock
 ]
 
+{ #category : #'visual properties' }
+SBButton >> makeBold [
+
+	self widget bold
+]
+
+{ #category : #'visual properties' }
+SBButton >> makeSmall [
+
+	self
+		cellGap: 4.0 sbScaled;
+		layoutInset: (4.0 @ 2.0) sbScaled.
+	
+	self widget
+		clearEmphasis;
+		small
+]
+
 { #category : #'event handling' }
 SBButton >> mouseDown [
 	
@@ -269,6 +287,12 @@ SBButton >> pressed: aBoolean [
 
 	pressed := aBoolean.
 	self changed
+]
+
+{ #category : #accessing }
+SBButton >> widget [
+
+	^ self submorphs detect: [:m | m isKindOf: SBStringMorph]
 ]
 
 { #category : #initialization }

--- a/packages/Sandblocks-Morphs/SBButton.class.st
+++ b/packages/Sandblocks-Morphs/SBButton.class.st
@@ -229,13 +229,16 @@ SBButton >> makeBold [
 { #category : #'visual properties' }
 SBButton >> makeSmall [
 
-	|widget|
+	| widget |
 	self
 		cellGap: 4.0 sbScaled;
-		layoutInset: (4.0 @ 2.0) sbScaled.
+		layoutInset: (6.0 @ 4.0) sbScaled.
 	
 	widget := self widgetMorph.
-	widget ifNotNil: [widget clearEmphasis; small]
+	widget ifNotNil: [
+		widget
+			clearEmphasis;
+			small]
 ]
 
 { #category : #'event handling' }

--- a/packages/Sandblocks-Morphs/SBButton.class.st
+++ b/packages/Sandblocks-Morphs/SBButton.class.st
@@ -141,9 +141,7 @@ SBButton >> icon: anIconMorph label: aString do: aBlock [
 	
 	self widget: anIconMorph shortcut: nil do: aBlock.
 	
-	self addMorphBack: (SBStringMorph new
-		contents: aString;
-		emphasis: TextEmphasis bold emphasisCode)
+	self addMorphBack: (self textMorphFor: aString)
 ]
 
 { #category : #initialization }
@@ -189,7 +187,7 @@ SBButton >> invokeMetaMenu: evt [
 SBButton >> label [
 
 	^ self submorphs
-		detect: [:m | m isKindOf: SBStringMorph]
+		detect: [:m | m isKindOf: self widgetClass ]
 		ifFound: [:m | m contents]
 		ifNone: [self name]
 ]
@@ -197,19 +195,15 @@ SBButton >> label [
 { #category : #accessing }
 SBButton >> label: aString [
 
-	(self submorphs detect: [:m | m isKindOf: SBStringMorph] ifNone: [
-		^ self addMorphFront: (SBStringMorph new
-			contents: aString;
-			emphasis: TextEmphasis bold emphasisCode)]) contents: aString
+	(self submorphs detect: [:m | m isKindOf: self widgetClass] ifNone: [
+		^ self addMorphFront: (self textMorphFor: aString)]) contents: aString
 ]
 
 { #category : #initialization }
 SBButton >> label: aString do: aBlock [
 
 	self
-		widget: (SBStringMorph new
-			contents: aString;
-			emphasis: TextEmphasis bold emphasisCode)
+		widget: (self textMorphFor: aString)
 		shortcut: nil
 		do: aBlock
 ]
@@ -219,9 +213,7 @@ SBButton >> label: aString shortcut: aShortcut do: aBlock [
 
 	self example: [SBButton new] args: [{'hello'. $p command. [nil]}] label: 'label'.
 	self
-		widget: (SBStringMorph new
-			contents: aString;
-			emphasis: TextEmphasis bold emphasisCode)
+		widget: (self textMorphFor: aString)
 		shortcut: aShortcut
 		do: aBlock
 ]
@@ -229,19 +221,21 @@ SBButton >> label: aString shortcut: aShortcut do: aBlock [
 { #category : #'visual properties' }
 SBButton >> makeBold [
 
-	self widget bold
+	|widget|
+	widget := self widgetMorph.
+	widget ifNotNil: [widget bold].
 ]
 
 { #category : #'visual properties' }
 SBButton >> makeSmall [
 
+	|widget|
 	self
 		cellGap: 4.0 sbScaled;
 		layoutInset: (4.0 @ 2.0) sbScaled.
 	
-	self widget
-		clearEmphasis;
-		small
+	widget := self widgetMorph.
+	widget ifNotNil: [widget clearEmphasis; small]
 ]
 
 { #category : #'event handling' }
@@ -289,10 +283,12 @@ SBButton >> pressed: aBoolean [
 	self changed
 ]
 
-{ #category : #accessing }
-SBButton >> widget [
+{ #category : #initialization }
+SBButton >> textMorphFor: aString [
 
-	^ self submorphs detect: [:m | m isKindOf: SBStringMorph]
+	^ self widgetClass new
+		contents: aString;
+		emphasis: TextEmphasis bold emphasisCode
 ]
 
 { #category : #initialization }
@@ -301,9 +297,23 @@ SBButton >> widget: aMorph shortcut: aShortcut do: aBlock [
 	action := aBlock.
 	self addMorphBack: aMorph.
 	aShortcut ifNotNil: [
-		self addMorphBack: (SBStringMorph new
+		self addMorphBack: (self widgetClass new
 			contents: (aShortcut isCollection
 				ifTrue: [aShortcut anyOne displayString]
 				ifFalse: [aShortcut displayString]);
 			opacity: 0.7)]
+]
+
+{ #category : #initialization }
+SBButton >> widgetClass [
+
+	^ SBStringMorph 
+]
+
+{ #category : #initialization }
+SBButton >> widgetMorph [
+
+	^ self submorphs detect: [:m | m isKindOf: self widgetClass] 
+		ifFound:[:m | m] 
+		ifNone: [nil]
 ]

--- a/packages/Sandblocks-Morphs/SBEditableButton.class.st
+++ b/packages/Sandblocks-Morphs/SBEditableButton.class.st
@@ -1,0 +1,31 @@
+Class {
+	#name : #SBEditableButton,
+	#superclass : #SBButton,
+	#category : #'Sandblocks-Morphs'
+}
+
+{ #category : #'as yet unclassified' }
+SBEditableButton >> widget: aMorph shortcut: aShortcut do: aBlock [
+
+	super widget: aMorph shortcut: aShortcut do: aBlock.
+	
+	self widgetMorph 
+			when: #contentsChanged
+			send: #triggerEvent:
+			to: self
+			with: #contentsChanged
+]
+
+{ #category : #initialization }
+SBEditableButton >> widgetClass [
+
+	^ SBTextBubble  
+]
+
+{ #category : #initialization }
+SBEditableButton >> widgetMorph [
+
+	^ self submorphs detect: [:m | m isKindOf: self widgetClass] 
+		ifFound:[:m | m textMorph] 
+		ifNone: [nil]
+]

--- a/packages/Sandblocks-Morphs/SBEditableButton.class.st
+++ b/packages/Sandblocks-Morphs/SBEditableButton.class.st
@@ -13,7 +13,13 @@ SBEditableButton >> widget: aMorph shortcut: aShortcut do: aBlock [
 			when: #contentsChanged
 			send: #triggerEvent:
 			to: self
-			with: #contentsChanged
+			with: #contentsChanged.
+			
+	self widgetMorph
+			when: #contentsChanged
+			send: #hResizing:
+			to: self
+			with: #shrinkWrap
 ]
 
 { #category : #initialization }

--- a/packages/Sandblocks-Morphs/SBEditableButton.class.st
+++ b/packages/Sandblocks-Morphs/SBEditableButton.class.st
@@ -19,7 +19,7 @@ SBEditableButton >> widget: aMorph shortcut: aShortcut do: aBlock [
 			when: #contentsChanged
 			send: #hResizing:
 			to: self
-			with: #shrinkWrap
+			with: self hResizing
 ]
 
 { #category : #initialization }

--- a/packages/Sandblocks-Morphs/SBEditableButton.class.st
+++ b/packages/Sandblocks-Morphs/SBEditableButton.class.st
@@ -4,22 +4,24 @@ Class {
 	#category : #'Sandblocks-Morphs'
 }
 
-{ #category : #'as yet unclassified' }
-SBEditableButton >> widget: aMorph shortcut: aShortcut do: aBlock [
+{ #category : #initialization }
+SBEditableButton >> textMorphFor: aString [
 
-	super widget: aMorph shortcut: aShortcut do: aBlock.
-	
-	self widgetMorph 
-			when: #contentsChanged
-			send: #triggerEvent:
-			to: self
-			with: #contentsChanged.
-			
-	self widgetMorph
-			when: #contentsChanged
-			send: #hResizing:
-			to: self
-			with: self hResizing
+	^ self widgetClass new
+		contents: aString;
+		emphasis: TextEmphasis bold emphasisCode;
+		bordered: false;
+		when: #clicked
+		send: #doButtonAction  
+		to: self;
+		when: #contentsChanged
+		send: #triggerEvent:
+		to: self
+		with: #contentsChanged;
+		when: #contentsChanged
+		send: #hResizing:
+		to: self
+		with: self hResizing
 ]
 
 { #category : #initialization }

--- a/packages/Sandblocks-Morphs/SBOwnTextMorph.class.st
+++ b/packages/Sandblocks-Morphs/SBOwnTextMorph.class.st
@@ -506,7 +506,7 @@ SBOwnTextMorph >> selectionBounds [
 { #category : #'as yet unclassified' }
 SBOwnTextMorph >> small [
 
-	self font: (TextStyle default fontOfSize: 8 sbScaled)
+	self font: (TextStyle default fontOfSize: 10 sbScaled)
 ]
 
 { #category : #'as yet unclassified' }

--- a/packages/Sandblocks-Morphs/SBOwnTextMorph.class.st
+++ b/packages/Sandblocks-Morphs/SBOwnTextMorph.class.st
@@ -504,6 +504,12 @@ SBOwnTextMorph >> selectionBounds [
 ]
 
 { #category : #'as yet unclassified' }
+SBOwnTextMorph >> small [
+
+	self font: (TextStyle default fontOfSize: 8 sbScaled)
+]
+
+{ #category : #'as yet unclassified' }
 SBOwnTextMorph >> stopEditing [
 
 	self cursor: 0

--- a/packages/Sandblocks-Morphs/SBStringMorph.class.st
+++ b/packages/Sandblocks-Morphs/SBStringMorph.class.st
@@ -107,7 +107,7 @@ SBStringMorph >> reportValue: anObject [
 { #category : #'as yet unclassified' }
 SBStringMorph >> small [
 
-	self font: (TextStyle default fontOfSize: 9 sbScaled)
+	self font: (TextStyle default fontOfSize: 10 sbScaled)
 ]
 
 { #category : #accessing }

--- a/packages/Sandblocks-Morphs/SBStringMorph.class.st
+++ b/packages/Sandblocks-Morphs/SBStringMorph.class.st
@@ -107,7 +107,7 @@ SBStringMorph >> reportValue: anObject [
 { #category : #'as yet unclassified' }
 SBStringMorph >> small [
 
-	self font: (TextStyle default fontOfSize: 8 sbScaled)
+	self font: (TextStyle default fontOfSize: 9 sbScaled)
 ]
 
 { #category : #accessing }

--- a/packages/Sandblocks-Morphs/SBStringMorph.class.st
+++ b/packages/Sandblocks-Morphs/SBStringMorph.class.st
@@ -104,6 +104,12 @@ SBStringMorph >> reportValue: anObject [
 	self contents: anObject printString
 ]
 
+{ #category : #'as yet unclassified' }
+SBStringMorph >> small [
+
+	self font: (TextStyle default fontOfSize: 8 sbScaled)
+]
+
 { #category : #accessing }
 SBStringMorph >> wantsMetaMenu [
 

--- a/packages/Sandblocks-Morphs/SBTabView.class.st
+++ b/packages/Sandblocks-Morphs/SBTabView.class.st
@@ -85,10 +85,10 @@ SBTabView >> addButton [
 
 	^ SBButton new
 		icon: (SBIcon iconPlus
-				size: 11.0;
+				size: 6.0 sbScaled;
 				color: (Color r: 0.0 g: 1 b: 0.0))
 			label: ''
-			do: [self add: (self active veryDeepCopy name: self activeName, '_copy')];
+			do: [self add: (self active veryDeepCopy name: self activeName)];
 		makeSmall;
 		cornerStyle: #squared;
 		cellGap: -1.0 sbScaled;
@@ -106,11 +106,7 @@ SBTabView >> asTabButton: aNamedBlock [
 		hResizing: #spaceFill.
 	
 	aNamedBlock = self active ifTrue: [button makeBold].
-	button
-		when: #contentsChanged
-		send: #updateNameFor:on:
-		to: self
-		withArguments: {aNamedBlock .  button}.
+	button when: #contentsChanged send: #updateNameFor:on: to: self withArguments: {aNamedBlock. button}.
 	
 	^ button
 		changeTableLayout;

--- a/packages/Sandblocks-Morphs/SBTabView.class.st
+++ b/packages/Sandblocks-Morphs/SBTabView.class.st
@@ -14,7 +14,9 @@ SBTabView class >> example [
 	SBMorphExample
 		setUp: [self newEmpty]
 		cases: {SBMorphExampleCase name: 'example 1' caseBlock: [:m | m]}
-		extent: 300 @ 300
+		extent: 300 @ 300.
+	
+	
 ]
 
 { #category : #'as yet unclassified' }
@@ -29,6 +31,26 @@ SBTabView class >> namedBlocks: aCollectionOfSBNamedBlocks activeIndex: aNumber 
 SBTabView class >> newEmpty [
 
 	^ self new updateTabs
+]
+
+{ #category : #'as yet unclassified' }
+SBTabView class >> registerShortcuts: aProvider [
+
+	aProvider registerShortcut: $n command do: #addTab.
+	aProvider registerShortcut: $w command do: #removeCurrentTab.
+	aProvider registerShortcut: Character arrowLeft  do: #jumpToPrevious.
+	aProvider registerShortcut: Character arrowRight  do: #jumpToNext.
+	
+	aProvider registerShortcut: $1 do: #jumpToFirstTab.
+	aProvider registerShortcut: $2 do: #jumpToSecondTab.
+	aProvider registerShortcut: $3 do: #jumpToThirdTab.
+	aProvider registerShortcut: $4 do: #jumpToFourthTab.
+	aProvider registerShortcut: $5 do: #jumpToFifthTab.
+	aProvider registerShortcut: $6 do: #jumpToSixthTab.
+	aProvider registerShortcut: $7 do: #jumpToSeventhTab.
+	aProvider registerShortcut: $8 do: #jumpToEightTab.
+	aProvider registerShortcut: $9 do: #jumpToNinthTab.
+	
 ]
 
 { #category : #'as yet unclassified' }
@@ -47,16 +69,6 @@ SBTabView >> activeBlock [
 SBTabView >> activeIndex [
 
 	^ activeIndex 
-]
-
-{ #category : #'as yet unclassified' }
-SBTabView >> activeIndex: aNumber [
-
-	self activeTab makeSmall.
-	
-	activeIndex := {aNumber. self namedBlocks size} min.
-	
-	self updateSelectedTab
 ]
 
 { #category : #'as yet unclassified' }
@@ -96,6 +108,13 @@ SBTabView >> addButton [
 ]
 
 { #category : #'as yet unclassified' }
+SBTabView >> addTab [
+	<action>
+
+	self add: (self namedBlocks last veryDeepCopy )
+]
+
+{ #category : #'as yet unclassified' }
 SBTabView >> asTabButton: aNamedBlock [
 
 	| button |
@@ -103,15 +122,15 @@ SBTabView >> asTabButton: aNamedBlock [
 		label: aNamedBlock name do: [self setActive: aNamedBlock];
 		cornerStyle: #squared;
 		makeSmall;
-		hResizing: #spaceFill.
+		hResizing: #spaceFill;
+		changeTableLayout;
+		listDirection: #leftToRight;
+		addMorphBack: (self deleteButtonFor: aNamedBlock).
 	
 	aNamedBlock = self active ifTrue: [button makeBold].
 	button when: #contentsChanged send: #updateNameFor:on: to: self withArguments: {aNamedBlock. button}.
 	
 	^ button
-		changeTableLayout;
-		listDirection: #leftToRight;
-		addMorphBack: (self deleteButtonFor: aNamedBlock)
 ]
 
 { #category : #'as yet unclassified' }
@@ -150,12 +169,6 @@ SBTabView >> deleteButtonFor: aNamedBlock [
 ]
 
 { #category : #'as yet unclassified' }
-SBTabView >> fixedNumberOfChildren [
-
-	^ false
-]
-
-{ #category : #'as yet unclassified' }
 SBTabView >> initialize [
 
 	super initialize.
@@ -168,6 +181,101 @@ SBTabView >> initialize [
 		listDirection: #topToBottom;
 		hResizing: #shrinkWrap;
 		vResizing: #shrinkWrap.
+]
+
+{ #category : #'shortcut-utility' }
+SBTabView >> jumpToEightTab [
+
+	<action>
+	self jumpToTab: 8
+	
+]
+
+{ #category : #'shortcut-utility' }
+SBTabView >> jumpToFifthTab [
+
+	<action>
+	self jumpToTab: 5
+	
+]
+
+{ #category : #'shortcut-utility' }
+SBTabView >> jumpToFirstTab [
+
+	<action>
+	self jumpToTab: 1
+	
+]
+
+{ #category : #'shortcut-utility' }
+SBTabView >> jumpToFourthTab [
+
+	<action>
+	self jumpToTab: 4
+	
+]
+
+{ #category : #'as yet unclassified' }
+SBTabView >> jumpToNext [
+
+	<action>
+	self jumpToTab: self activeIndex  \\ self namedBlocks size + 1
+	
+]
+
+{ #category : #'shortcut-utility' }
+SBTabView >> jumpToNinthTab [
+
+	<action>
+	self jumpToTab: 9
+	
+]
+
+{ #category : #'as yet unclassified' }
+SBTabView >> jumpToPrevious [
+
+	<action>
+	self jumpToTab: self activeIndex - 2 \\ self namedBlocks size + 1
+	
+]
+
+{ #category : #'shortcut-utility' }
+SBTabView >> jumpToSecondTab [
+
+	<action>
+	self jumpToTab: 2
+	
+]
+
+{ #category : #'shortcut-utility' }
+SBTabView >> jumpToSeventhTab [
+
+	<action>
+	self jumpToTab: 7
+	
+]
+
+{ #category : #'shortcut-utility' }
+SBTabView >> jumpToSixthTab [
+
+	<action>
+	self jumpToTab: 6
+	
+]
+
+{ #category : #'as yet unclassified' }
+SBTabView >> jumpToTab: anIndex [
+
+	self namedBlocks at: anIndex ifPresent: [:block | self setActive: block]
+	
+]
+
+{ #category : #'shortcut-utility' }
+SBTabView >> jumpToThirdTab [
+
+	<action>
+	self jumpToTab: 3
+	
 ]
 
 { #category : #'as yet unclassified' }
@@ -194,18 +302,6 @@ SBTabView >> namedBlocks: aCollectionOfSBNamedBlocks activeIndex: aNumber [
 ]
 
 { #category : #'as yet unclassified' }
-SBTabView >> newEmptyChildNear: aBlock before: aBoolean [
-
-    ^ SBNamedBlock new
-]
-
-{ #category : #'as yet unclassified' }
-SBTabView >> objectInterfaceNear: aBlock at: aSymbol [
-
-	^ {[:o | o isKindOf: SBNamedBlock ]}
-]
-
-{ #category : #'as yet unclassified' }
 SBTabView >> remove: aNamedBlock [
 
 	(self namedBlocks indexOf: aNamedBlock) <= activeIndex ifTrue: [activeIndex := {activeIndex - 1. 1} max].
@@ -220,11 +316,18 @@ SBTabView >> remove: aNamedBlock [
 ]
 
 { #category : #'as yet unclassified' }
+SBTabView >> removeCurrentTab [
+	<action>
+
+	self remove: self active
+]
+
+{ #category : #'as yet unclassified' }
 SBTabView >> setActive: aNamedBlock [
 
 	self activeTab makeSmall.
 	
-	activeIndex := self namedBlocks indexOf: aNamedBlock ifAbsent: 1.
+	activeIndex := (self namedBlocks indexOf: aNamedBlock ifAbsent: 1).
 	
 	self updateSelectedTab
 ]
@@ -251,7 +354,8 @@ SBTabView >> updateSelectedTab [
 	(self tabs at: activeIndex) makeBold.
 	
 	"so that bold text does not go over its borders"
-	self tabs do: [:aButton | aButton widgetMorph hResizing: self hResizing]
+	self tabs do: [:aButton | aButton widgetMorph hResizing: self hResizing].
+	self triggerEvent: #changedActive.
 ]
 
 { #category : #'as yet unclassified' }
@@ -261,5 +365,7 @@ SBTabView >> updateTabs [
 	
 	self
 		buildTabs;
-		buildView
+		buildView.
+		
+	self triggerEvent: #changedActive
 ]

--- a/packages/Sandblocks-Morphs/SBTabView.class.st
+++ b/packages/Sandblocks-Morphs/SBTabView.class.st
@@ -85,8 +85,8 @@ SBTabView >> addButton [
 
 	^ SBButton new
 		icon: (SBIcon iconPlus
-				size: 8.0;
-				color: Color green)
+				size: 11.0;
+				color: (Color r: 0.0 g: 1 b: 0.0))
 			label: ''
 			do: [self add: (self active veryDeepCopy name: self activeName, '_copy')];
 		makeSmall;
@@ -242,7 +242,8 @@ SBTabView >> tabs [
 { #category : #'as yet unclassified' }
 SBTabView >> updateNameFor: aNamedBlock on: aSBButton [
 
-	aNamedBlock name: aSBButton label
+	aNamedBlock name: aSBButton label.
+	self tabs do: [:aTab | aTab hResizing: self hResizing]
 ]
 
 { #category : #'as yet unclassified' }
@@ -251,7 +252,10 @@ SBTabView >> updateSelectedTab [
 	self lastSubmorph delete.
 	
 	self buildView.
-	(self tabs at: activeIndex) makeBold  	
+	(self tabs at: activeIndex) makeBold.
+	
+	"so that bold text does not go over its borders"
+	self tabs do: [:aButton | aButton widgetMorph hResizing: self hResizing]
 ]
 
 { #category : #'as yet unclassified' }

--- a/packages/Sandblocks-Morphs/SBTabView.class.st
+++ b/packages/Sandblocks-Morphs/SBTabView.class.st
@@ -12,15 +12,23 @@ Class {
 SBTabView class >> example [
 
 	SBMorphExample
-		setUp: [self new]
+		setUp: [self newEmpty]
 		cases: {SBMorphExampleCase name: 'example 1' caseBlock: [:m | m]}
 		extent: 300 @ 300
 ]
 
 { #category : #'as yet unclassified' }
-SBTabView class >> namedBlocks: aCollectionOfSBNamedBlocks [
+SBTabView class >> namedBlocks: aCollectionOfSBNamedBlocks activeIndex: aNumber [
 
 	^ self new namedBlocks: aCollectionOfSBNamedBlocks
+		     activeIndex: aNumber;
+		     yourself 
+]
+
+{ #category : #'as yet unclassified' }
+SBTabView class >> newEmpty [
+
+	^ self new updateTabs
 ]
 
 { #category : #'as yet unclassified' }
@@ -39,6 +47,16 @@ SBTabView >> activeBlock [
 SBTabView >> activeIndex [
 
 	^ activeIndex 
+]
+
+{ #category : #'as yet unclassified' }
+SBTabView >> activeIndex: aNumber [
+
+	self activeTab makeSmall.
+	
+	activeIndex := {aNumber. self namedBlocks size} min.
+	
+	self updateSelectedTab
 ]
 
 { #category : #'as yet unclassified' }
@@ -81,14 +99,18 @@ SBTabView >> addButton [
 SBTabView >> asTabButton: aNamedBlock [
 
 	| button |
-	button := SBButton new
+	button := SBEditableButton new
 		label: aNamedBlock name do: [self setActive: aNamedBlock];
 		cornerStyle: #squared;
 		makeSmall;
 		hResizing: #spaceFill.
 	
 	aNamedBlock = self active ifTrue: [button makeBold].
-	
+	button
+		when: #contentsChanged
+		send: #updateNameFor:on:
+		to: self
+		withArguments: {aNamedBlock .  button}.
 	
 	^ button
 		changeTableLayout;
@@ -150,8 +172,6 @@ SBTabView >> initialize [
 		listDirection: #topToBottom;
 		hResizing: #shrinkWrap;
 		vResizing: #shrinkWrap.
-	
-	self updateTabs
 ]
 
 { #category : #'as yet unclassified' }
@@ -164,7 +184,17 @@ SBTabView >> namedBlocks [
 SBTabView >> namedBlocks: aCollectionOfSBBlocks [
 
 	namedBlocks := aCollectionOfSBBlocks asOrderedCollection.
+	activeIndex := namedBlocks size.
 	self updateTabs
+]
+
+{ #category : #'as yet unclassified' }
+SBTabView >> namedBlocks: aCollectionOfSBNamedBlocks activeIndex: aNumber [
+
+	namedBlocks := aCollectionOfSBNamedBlocks asOrderedCollection.
+	activeIndex := {aNumber. self namedBlocks size} min.
+	
+	self updateTabs.
 ]
 
 { #category : #'as yet unclassified' }
@@ -206,6 +236,12 @@ SBTabView >> setActive: aNamedBlock [
 SBTabView >> tabs [
 
 	^ (self submorphNamed: #tabs) submorphs
+]
+
+{ #category : #'as yet unclassified' }
+SBTabView >> updateNameFor: aNamedBlock on: aSBButton [
+
+	aNamedBlock name: aSBButton label
 ]
 
 { #category : #'as yet unclassified' }

--- a/packages/Sandblocks-Morphs/SBTabView.class.st
+++ b/packages/Sandblocks-Morphs/SBTabView.class.st
@@ -8,7 +8,7 @@ Class {
 	#category : #'Sandblocks-Morphs'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #examples }
 SBTabView class >> example [
 
 	SBMorphExample
@@ -19,7 +19,7 @@ SBTabView class >> example [
 	
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'instance creation' }
 SBTabView class >> namedBlocks: aCollectionOfSBNamedBlocks activeIndex: aNumber [
 
 	^ self new namedBlocks: aCollectionOfSBNamedBlocks
@@ -27,13 +27,13 @@ SBTabView class >> namedBlocks: aCollectionOfSBNamedBlocks activeIndex: aNumber 
 		     yourself 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'instance creation' }
 SBTabView class >> newEmpty [
 
-	^ self new updateTabs
+	^ self new rebuild
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #shortcuts }
 SBTabView class >> registerShortcuts: aProvider [
 
 	aProvider registerShortcut: $n command do: #addTab.
@@ -53,46 +53,62 @@ SBTabView class >> registerShortcuts: aProvider [
 	
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBTabView >> active [
 
 	^ self namedBlocks at: activeIndex
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBTabView >> activeBlock [
 
 	^ self active block
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBTabView >> activeIndex [
 
 	^ activeIndex 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
+SBTabView >> activeIndex: aNumber [ 
+
+	self activeTab makeSmall.
+
+	activeIndex := {aNumber. self namedBlocks size} min.
+
+	self updateSelectedTab.
+	
+	self triggerEvent: #changedActive
+]
+
+{ #category : #accessing }
 SBTabView >> activeName [
 
 	^ self active name
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBTabView >> activeTab [
 
 	^ self tabs at: activeIndex 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tabs }
 SBTabView >> add: aNamedBlock [
-
-	self namedBlocks add: aNamedBlock.
-	activeIndex := self namedBlocks size.
 	
-	self updateTabs
+	|oldValue|
+	oldValue := self namedBlocks veryDeepCopy.
+	self namedBlocks add: aNamedBlock.
+	
+	self sandblockEditor do: (SBCombinedCommand newWith: {
+		self switchCommandFor: self namedBlocks size oldValue: self activeIndex.
+		(self addOrRemoveCommandFor: oldValue).
+		})
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #ui }
 SBTabView >> addButton [
 
 	^ SBButton new
@@ -100,21 +116,32 @@ SBTabView >> addButton [
 				size: 6.0 sbScaled;
 				color: (Color r: 0.0 g: 1 b: 0.0))
 			label: ''
-			do: [self add: (self active veryDeepCopy name: self activeName)];
+			do: [self addTab];
 		makeSmall;
 		cornerStyle: #squared;
 		cellGap: -1.0 sbScaled;
 		layoutInset: (4.0 @ 4.0) sbScaled
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #commands }
+SBTabView >> addOrRemoveCommandFor: anOldCollectionOfNamedBlocks [
+
+	^SBMutatePropertyCommand new 
+		target: self;
+		selector: #namedBlocks;
+		mutateSelector: #namedBlocks:;
+		oldValue: anOldCollectionOfNamedBlocks;
+		value: self namedBlocks
+]
+
+{ #category : #actions }
 SBTabView >> addTab [
 	<action>
 
-	self add: (self namedBlocks last veryDeepCopy )
+	self add: (self active veryDeepCopy name: self activeName, '_i')
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #ui }
 SBTabView >> asTabButton: aNamedBlock [
 
 	| button |
@@ -133,7 +160,7 @@ SBTabView >> asTabButton: aNamedBlock [
 	^ button
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #ui }
 SBTabView >> buildTabs [
 
 	self addMorphBack: (SBRow new
@@ -145,13 +172,13 @@ SBTabView >> buildTabs [
 		hResizing: #shrinkWrap)
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #ui }
 SBTabView >> buildView [
 
-	self addMorphBack: self activeBlock
+	self addMorphBack: (self activeBlock hResizing: #spaceFill)
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #ui }
 SBTabView >> deleteButtonFor: aNamedBlock [
 
 	| delete |
@@ -168,7 +195,7 @@ SBTabView >> deleteButtonFor: aNamedBlock [
 	^ delete
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #initialization }
 SBTabView >> initialize [
 
 	super initialize.
@@ -179,7 +206,7 @@ SBTabView >> initialize [
 	self
 		changeTableLayout;
 		listDirection: #topToBottom;
-		hResizing: #shrinkWrap;
+		hResizing: #spaceFill;
 		vResizing: #shrinkWrap.
 ]
 
@@ -215,7 +242,7 @@ SBTabView >> jumpToFourthTab [
 	
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #actions }
 SBTabView >> jumpToNext [
 
 	<action>
@@ -231,7 +258,7 @@ SBTabView >> jumpToNinthTab [
 	
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #actions }
 SBTabView >> jumpToPrevious [
 
 	<action>
@@ -263,7 +290,7 @@ SBTabView >> jumpToSixthTab [
 	
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tabs }
 SBTabView >> jumpToTab: anIndex [
 
 	self namedBlocks at: anIndex ifPresent: [:block | self setActive: block]
@@ -278,94 +305,126 @@ SBTabView >> jumpToThirdTab [
 	
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBTabView >> namedBlocks [
 
 	^ namedBlocks
 ]
 
-{ #category : #'as yet unclassified' }
-SBTabView >> namedBlocks: aCollectionOfSBBlocks [
+{ #category : #accessing }
+SBTabView >> namedBlocks: aCollectionOfSBNamedBlocks [
 
-	namedBlocks := aCollectionOfSBBlocks asOrderedCollection.
-	activeIndex := namedBlocks size.
-	self updateTabs
+	self namedBlocks: aCollectionOfSBNamedBlocks activeIndex: namedBlocks size
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBTabView >> namedBlocks: aCollectionOfSBNamedBlocks activeIndex: aNumber [
 
 	namedBlocks := aCollectionOfSBNamedBlocks asOrderedCollection.
 	activeIndex := {aNumber. self namedBlocks size} min.
 	
-	self updateTabs.
+	self rebuild
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #ui }
+SBTabView >> rebuild [
+
+	self submorphs copy do: #delete.
+	
+	self
+		buildTabs;
+		buildView
+]
+
+{ #category : #tabs }
 SBTabView >> remove: aNamedBlock [
 
-	(self namedBlocks indexOf: aNamedBlock) <= activeIndex ifTrue: [activeIndex := {activeIndex - 1. 1} max].
-	
-	self namedBlocks remove: aNamedBlock ifAbsent: [].
-	
-	self namedBlocks ifEmpty: [
-		self triggerEvent: #deletedLastTab with: aNamedBlock.
+	| oldValue newIndex oldIndex |
+	(self namedBlocks size - 1 <= 0) ifTrue: [
+		self triggerEvent: #deletedLastTab with: aNamedBlock veryDeepCopy.
 		^ self delete].
 	
-	self updateTabs
+	(self namedBlocks indexOf: aNamedBlock) <= self activeIndex 
+		ifTrue: [newIndex := {activeIndex - 1. 1} max]
+		ifFalse: [newIndex := self activeIndex].
+	oldValue := self namedBlocks veryDeepCopy.
+	oldIndex := self activeIndex.
+	
+	self namedBlocks remove: aNamedBlock ifAbsent: [].
+	self sandblockEditor do: (SBCombinedCommand newWith: {
+	"When removing, in order for the undo function to switch to the previous active tab,
+	the remove command has to be wrapped"
+		self switchCommandFor: newIndex oldValue: oldIndex.
+		(self addOrRemoveCommandFor: oldValue).
+		self switchCommandFor: newIndex oldValue: oldIndex.
+		})
+
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #actions }
 SBTabView >> removeCurrentTab [
 	<action>
 
 	self remove: self active
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tabs }
 SBTabView >> setActive: aNamedBlock [
 
-	self activeTab makeSmall.
-	
-	activeIndex := (self namedBlocks indexOf: aNamedBlock ifAbsent: 1).
-	
-	self updateSelectedTab
+	self sandblockEditor do: 
+		(self switchCommandFor: (self namedBlocks indexOf: aNamedBlock ifAbsent: 1))
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #commands }
+SBTabView >> switchCommandFor: aNumber [
+
+	^ SBMutatePropertyCommand new
+		target: self;
+		selector: #activeIndex;
+		mutateSelector: #activeIndex:;
+		value: aNumber
+]
+
+{ #category : #commands }
+SBTabView >> switchCommandFor: aNumber oldValue: oldNumber [
+
+	^ SBMutatePropertyCommand new
+		target: self;
+		selector: #activeIndex;
+		mutateSelector: #activeIndex:;
+		value: aNumber;
+		oldValue: oldNumber
+]
+
+{ #category : #accessing }
 SBTabView >> tabs [
 
 	^ (self submorphNamed: #tabs) submorphs
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #ui }
 SBTabView >> updateNameFor: aNamedBlock on: aSBButton [
 
 	aNamedBlock name: aSBButton label.
-	self tabs do: [:aTab | aTab hResizing: self hResizing]
+	
+	"Changing the extent of a tab should not affect other tabs, 
+	e.g. making a tab smaller should not make the left neighbor larger"
+	self tabs do: [:aTab | aTab hResizing: #shrinkWrap]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #ui }
 SBTabView >> updateSelectedTab [
 
-	self lastSubmorph delete.
-	
+	self view delete.
 	self buildView.
-	(self tabs at: activeIndex) makeBold.
 	
+	(self tabs at: self activeIndex) makeBold.
 	"so that bold text does not go over its borders"
-	self tabs do: [:aButton | aButton widgetMorph hResizing: self hResizing].
-	self triggerEvent: #changedActive.
+	self tabs do: [:aButton | aButton widgetMorph hResizing: self hResizing]
 ]
 
-{ #category : #'as yet unclassified' }
-SBTabView >> updateTabs [
+{ #category : #accessing }
+SBTabView >> view [
 
-	self submorphs copy do: #delete.
-	
-	self
-		buildTabs;
-		buildView.
-		
-	self triggerEvent: #changedActive
+	^ self lastSubmorph
 ]

--- a/packages/Sandblocks-Morphs/SBTabView.class.st
+++ b/packages/Sandblocks-Morphs/SBTabView.class.st
@@ -212,12 +212,13 @@ SBTabView >> objectInterfaceNear: aBlock at: aSymbol [
 { #category : #'as yet unclassified' }
 SBTabView >> remove: aNamedBlock [
 
-	((self namedBlocks indexOf: aNamedBlock) <= activeIndex) 
-		ifTrue:  [activeIndex := {activeIndex - 1. 1} max]. 
+	(self namedBlocks indexOf: aNamedBlock) <= activeIndex ifTrue: [activeIndex := {activeIndex - 1. 1} max].
 	
 	self namedBlocks remove: aNamedBlock ifAbsent: [].
 	
-	self namedBlocks ifEmpty: [^ self delete].
+	self namedBlocks ifEmpty: [
+		self triggerEvent: #deletedLastTab with: aNamedBlock.
+		^ self delete].
 	
 	self updateTabs
 ]

--- a/packages/Sandblocks-Morphs/SBTabView.class.st
+++ b/packages/Sandblocks-Morphs/SBTabView.class.st
@@ -1,0 +1,228 @@
+Class {
+	#name : #SBTabView,
+	#superclass : #SBBlock,
+	#instVars : [
+		'namedBlocks',
+		'activeIndex'
+	],
+	#category : #'Sandblocks-Morphs'
+}
+
+{ #category : #'as yet unclassified' }
+SBTabView class >> example [
+
+	SBMorphExample
+		setUp: [self new]
+		cases: {SBMorphExampleCase name: 'example 1' caseBlock: [:m | m]}
+		extent: 300 @ 300
+]
+
+{ #category : #'as yet unclassified' }
+SBTabView class >> namedBlocks: aCollectionOfSBNamedBlocks [
+
+	^ self new namedBlocks: aCollectionOfSBNamedBlocks
+]
+
+{ #category : #'as yet unclassified' }
+SBTabView >> active [
+
+	^ self namedBlocks at: activeIndex
+]
+
+{ #category : #'as yet unclassified' }
+SBTabView >> activeBlock [
+
+	^ self active block
+]
+
+{ #category : #'as yet unclassified' }
+SBTabView >> activeIndex [
+
+	^ activeIndex 
+]
+
+{ #category : #'as yet unclassified' }
+SBTabView >> activeName [
+
+	^ self active name
+]
+
+{ #category : #'as yet unclassified' }
+SBTabView >> activeTab [
+
+	^ self tabs at: activeIndex 
+]
+
+{ #category : #'as yet unclassified' }
+SBTabView >> add: aNamedBlock [
+
+	self namedBlocks add: aNamedBlock.
+	activeIndex := self namedBlocks size.
+	
+	self updateTabs
+]
+
+{ #category : #'as yet unclassified' }
+SBTabView >> addButton [
+
+	^ SBButton new
+		icon: (SBIcon iconPlus
+				size: 8.0;
+				color: Color green)
+			label: ''
+			do: [self add: (self active veryDeepCopy name: self activeName, '_copy')];
+		makeSmall;
+		cornerStyle: #squared;
+		cellGap: -1.0 sbScaled;
+		layoutInset: (4.0 @ 4.0) sbScaled
+]
+
+{ #category : #'as yet unclassified' }
+SBTabView >> asTabButton: aNamedBlock [
+
+	| button |
+	button := SBButton new
+		label: aNamedBlock name do: [self setActive: aNamedBlock];
+		cornerStyle: #squared;
+		makeSmall;
+		hResizing: #spaceFill.
+	
+	aNamedBlock = self active ifTrue: [button makeBold].
+	
+	
+	^ button
+		changeTableLayout;
+		listDirection: #leftToRight;
+		addMorphBack: (self deleteButtonFor: aNamedBlock)
+]
+
+{ #category : #'as yet unclassified' }
+SBTabView >> buildTabs [
+
+	self addMorphBack: (SBRow new
+		addAllMorphsBack: (self namedBlocks collect: [:block | self asTabButton: block]);
+		name: #tabs;
+		addMorphBack: self addButton;
+		changeTableLayout;
+		listDirection: #leftToRight;
+		hResizing: #shrinkWrap)
+]
+
+{ #category : #'as yet unclassified' }
+SBTabView >> buildView [
+
+	self addMorphBack: self activeBlock
+]
+
+{ #category : #'as yet unclassified' }
+SBTabView >> deleteButtonFor: aNamedBlock [
+
+	| delete |
+	delete := SBButton new
+		icon: (SBIcon iconTimes
+				size: 8;
+				color: Color red)
+			label: ''
+			do: [self remove: aNamedBlock];
+		makeSmall;
+		cornerStyle: #squared;
+		layoutInset: (0.0 @ 1.0) sbScaled;
+		cellGap: -1.0 sbScaled.
+	^ delete
+]
+
+{ #category : #'as yet unclassified' }
+SBTabView >> fixedNumberOfChildren [
+
+	^ false
+]
+
+{ #category : #'as yet unclassified' }
+SBTabView >> initialize [
+
+	super initialize.
+	
+	namedBlocks := {SBNamedBlock new} asOrderedCollection.
+	activeIndex := 1.
+	
+	self
+		changeTableLayout;
+		listDirection: #topToBottom;
+		hResizing: #shrinkWrap;
+		vResizing: #shrinkWrap.
+	
+	self updateTabs
+]
+
+{ #category : #'as yet unclassified' }
+SBTabView >> namedBlocks [
+
+	^ namedBlocks
+]
+
+{ #category : #'as yet unclassified' }
+SBTabView >> namedBlocks: aCollectionOfSBBlocks [
+
+	namedBlocks := aCollectionOfSBBlocks asOrderedCollection.
+	self updateTabs
+]
+
+{ #category : #'as yet unclassified' }
+SBTabView >> newEmptyChildNear: aBlock before: aBoolean [
+
+    ^ SBNamedBlock new
+]
+
+{ #category : #'as yet unclassified' }
+SBTabView >> objectInterfaceNear: aBlock at: aSymbol [
+
+	^ {[:o | o isKindOf: SBNamedBlock ]}
+]
+
+{ #category : #'as yet unclassified' }
+SBTabView >> remove: aNamedBlock [
+
+	((self namedBlocks indexOf: aNamedBlock) <= activeIndex) 
+		ifTrue:  [activeIndex := {activeIndex - 1. 1} max]. 
+	
+	self namedBlocks remove: aNamedBlock ifAbsent: [].
+	
+	self namedBlocks ifEmpty: [^ self delete].
+	
+	self updateTabs
+]
+
+{ #category : #'as yet unclassified' }
+SBTabView >> setActive: aNamedBlock [
+
+	self activeTab makeSmall.
+	
+	activeIndex := self namedBlocks indexOf: aNamedBlock ifAbsent: 1.
+	
+	self updateSelectedTab
+]
+
+{ #category : #'as yet unclassified' }
+SBTabView >> tabs [
+
+	^ (self submorphNamed: #tabs) submorphs
+]
+
+{ #category : #'as yet unclassified' }
+SBTabView >> updateSelectedTab [
+
+	self lastSubmorph delete.
+	
+	self buildView.
+	(self tabs at: activeIndex) makeBold  	
+]
+
+{ #category : #'as yet unclassified' }
+SBTabView >> updateTabs [
+
+	self submorphs copy do: #delete.
+	
+	self
+		buildTabs;
+		buildView
+]

--- a/packages/Sandblocks-Smalltalk/SBStASTNode.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStASTNode.class.st
@@ -25,6 +25,7 @@ SBStASTNode class >> registerShortcuts: aProvider [
 
 	aProvider
 		cmdShortcut: $" do: #wrapInToggledCode;
+		cmdShortcut: $Q do: #wrapInVariant;
 		noInsertShortcut: $[ do: #wrapInBlock;
 		noInsertShortcut: ${ do: #wrapInDynamicArray;
 		cmdShortcut: $: do: #wrapInAssignment;

--- a/packages/Sandblocks-Smalltalk/SBStGrammarHandler.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStGrammarHandler.class.st
@@ -546,6 +546,24 @@ SBStGrammarHandler >> wrapInToggledCode [
 ]
 
 { #category : #actions }
+SBStGrammarHandler >> wrapInVariant [
+	<multiSelectAction>
+	<actionValidIf: #canAppearInBlockBody>
+
+	| variant |
+	self assert: self block isSelected.
+	variant := SBVariant new.
+	self block sandblockEditor multiSelectionIsConsecutive ifFalse: [^ self].
+	self block sandblockEditor doMultiSelection: [:selected |
+		SBWrapConsecutiveCommand new
+			selectAfter: #block;
+			outer: variant;
+			targets: selected;
+			wrap: [:outer :inner | variant named: 'Variants for Block' alternatives:{SBNamedBlock block: (SBStBlockBody new statements: inner) named:'A variant'} activeIndex: 1];
+			yourself]
+]
+
+{ #category : #actions }
 SBStGrammarHandler >> wrapWithExampleWatch [
 	<action>
 	<actionValidIf: #isExpression>

--- a/packages/Sandblocks-Smalltalk/SBStGrammarHandler.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStGrammarHandler.class.st
@@ -548,7 +548,7 @@ SBStGrammarHandler >> wrapInToggledCode [
 { #category : #actions }
 SBStGrammarHandler >> wrapInVariant [
 	<multiSelectAction>
-	<actionValidIf: #canAppearInBlockBody>
+	<actionValidIf: #isSandblock>
 
 	| variant |
 	self assert: self block isSelected.
@@ -559,7 +559,7 @@ SBStGrammarHandler >> wrapInVariant [
 			selectAfter: #block;
 			outer: variant;
 			targets: selected;
-			wrap: [:outer :inner | variant named: 'Variant' alternatives:{SBNamedBlock block: (SBStBlockBody new statements: inner) named:'alt'} activeIndex: 1];
+			wrap: [:outer :inner | variant named: inner printString alternatives:{SBNamedBlock block: (SBStBlockBody new statements: inner) named:'alt'} activeIndex: 1];
 			yourself]
 ]
 

--- a/packages/Sandblocks-Smalltalk/SBStGrammarHandler.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStGrammarHandler.class.st
@@ -559,7 +559,7 @@ SBStGrammarHandler >> wrapInVariant [
 			selectAfter: #block;
 			outer: variant;
 			targets: selected;
-			wrap: [:outer :inner | variant named: 'Variants for Block' alternatives:{SBNamedBlock block: (SBStBlockBody new statements: inner) named:'A variant'} activeIndex: 1];
+			wrap: [:outer :inner | variant named: 'Variant' alternatives:{SBNamedBlock block: (SBStBlockBody new statements: inner) named:'alt'} activeIndex: 1];
 			yourself]
 ]
 

--- a/packages/Sandblocks-Smalltalk/SBVariant.class.st
+++ b/packages/Sandblocks-Smalltalk/SBVariant.class.st
@@ -114,14 +114,20 @@ SBVariant >> drawnColor [
 ]
 
 { #category : #'as yet unclassified' }
+SBVariant >> handlesMouseOver: anEvent [
+
+	^ true
+	
+]
+
+{ #category : #'as yet unclassified' }
 SBVariant >> initialize [
 
 	super initialize.
 	
 	name := SBTextBubble new
 		contents: 'variant X';
-		layoutInset: 5 @ 5;
-		font: (TextStyle default fontOfSize: 8.0 sbScaled).
+		layoutInset: 5 @ 5.
 	widget := SBTabView
 		namedBlocks: {SBNamedBlock block: (SBStBlockBody emptyWithDeclarations: {'a'. 'c'}) named: 'Code'}
 		activeIndex: 1.
@@ -129,13 +135,27 @@ SBVariant >> initialize [
 	widget when: #deletedLastTab send: #replaceSelfWithChosenBlock: to: self.
 	
 	self
-		layoutInset: 2;
-		cellGap: 4;
+		layoutInset: 0;
+		cellGap: 0;
 		vResizing: #shrinkWrap;
 		hResizing: #shrinkWrap;
 		changeTableLayout;
 		listDirection: #topToBottom;
-		addAllMorphsBack: {name. widget}
+		addAllMorphsBack: {widget}
+]
+
+{ #category : #'as yet unclassified' }
+SBVariant >> mouseEnter: anEvent [
+
+	super mouseEnter: anEvent.
+	self addMorphBack: name
+]
+
+{ #category : #'as yet unclassified' }
+SBVariant >> mouseLeave: anEvent [
+
+	super mouseLeave: anEvent.
+	self removeMorph: name
 ]
 
 { #category : #'as yet unclassified' }

--- a/packages/Sandblocks-Smalltalk/SBVariant.class.st
+++ b/packages/Sandblocks-Smalltalk/SBVariant.class.st
@@ -8,7 +8,7 @@ Class {
 	#category : #'Sandblocks-Smalltalk'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 SBVariant class >> example [
 
 	SBMorphExample
@@ -19,46 +19,46 @@ SBVariant class >> example [
 	
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #suggestions }
 SBVariant class >> instanceSuggestion [
 
 	^ [self newEmpty]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 SBVariant class >> matches: aBlock [
 
 	(super matches: aBlock) ifFalse: [^ false].
 	
 	^ aBlock receiver isBinding
 		and: [aBlock receiver contents = 'SBVariant']
-		and: [aBlock selector = 'named:associations:do:']
+		and: [aBlock selector = 'named:associations:activeIndex:']
 ]
 
-{ #category : #nil }
+{ #category : #'instance creation' }
 SBVariant class >> named: aString alternatives: aCollectionOfNamedBlocks activeIndex: aNumber [
 
 	^ self new
-		name: aString
+		named: aString
 		alternatives: aCollectionOfNamedBlocks
 		activeIndex: aNumber
 		
 ]
 
-{ #category : #nil }
+{ #category : #'instance creation' }
 SBVariant class >> named: aString associations: aCollectionOfAssociations activeIndex: aNumber [
 
 	^ aNumber > 0 ifTrue: [(aCollectionOfAssociations at: aNumber) value value] ifFalse: [nil]
 		
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'instance creation' }
 SBVariant class >> newEmpty [
 
 	^ self new
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'instance creation' }
 SBVariant class >> newFor: aBlock [
 
 	^ self
@@ -67,50 +67,50 @@ SBVariant class >> newFor: aBlock [
 		activeIndex: aBlock arguments third parsedContents
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #shortcuts }
 SBVariant class >> registerShortcuts: aProvider [
 
 	aProvider registerShortcut: $f command do: #replaceSelfWithChosen.
 	
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBVariant >> active [
 
 	^ self widget active
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBVariant >> activeBlock [
 
 	^ self widget activeBlock
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBVariant >> activeIndex [
 
 	^ self widget activeIndex
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBVariant >> alternatives [
 
 	^ self widget namedBlocks
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBVariant >> color [
 
 	^ Color transparent
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBVariant >> drawnColor [
 
 	^ Color white
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #initialization }
 SBVariant >> initialize [
 
 	super initialize.
@@ -118,82 +118,92 @@ SBVariant >> initialize [
 	name := SBLabel new
 		contents: 'variant X';
 		layoutInset: 5 @ 5;
-		vResizing: #shrinkWrap.
-	widget := SBTabView
+		hResizing: #spaceFill.
+	self widget: (SBTabView
 		namedBlocks: {SBNamedBlock block: (SBStBlockBody emptyWithDeclarations: {'a'. 'c'}) named: 'Code'}
-		activeIndex: 1.
-	
-	widget when: #deletedLastTab send: #replaceSelfWithBlock: to: self.
-	widget when: #changedActive send: #updateResize to: self.
+		activeIndex: 1).
 	
 	
 	self
 		layoutInset: 0;
 		cellGap: 2.0;
-		vResizing: #shrinkWrap;
-		hResizing: #shrinkWrap;
+		listDirection: #topToBottom;
 		changeTableLayout;
-		listDirection: #leftToRight;
-		addAllMorphsBack: {name. widget}
+		addAllMorphsBack: {name. widget};
+		vResizing: #shrinkWrap;
+		hResizing: #shrinkWrap
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBVariant >> name [
 
 	^ name contents
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBVariant >> name: aString [
 	name contents: aString
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #initialization }
 SBVariant >> named: aString alternatives: aCollectionOfNamedBlocks activeIndex: aNumber [
 
 	self name: aString.
 	self widget namedBlocks: aCollectionOfNamedBlocks activeIndex: aNumber
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBVariant >> namedBlocks [ 
 
 	^ self widget namedBlocks 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #actions }
 SBVariant >> replaceSelfWithBlock: aNamedBlock [
 	
-	self replaceBlock: aNamedBlock block lastSubmorph
+	"As deleting the last tab also deletes the tab view, we gotta recreate it"
+	self widget: (SBTabView namedBlocks: {aNamedBlock} activeIndex: 1).
+	self addMorphBack: widget.
+	
+	self sandblockEditor do: (SBUnwrapConsecutiveCommand new 
+									target: self; 
+									unwrapped: {widget activeBlock lastSubmorph})
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #actions }
 SBVariant >> replaceSelfWithChosen [ 
 	
 	<action>
-	self replaceSelfWithBlock: self active
+	self sandblockEditor do: (SBUnwrapConsecutiveCommand new 
+									target: self; 
+									unwrapped: {self activeBlock lastSubmorph})
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #ui }
 SBVariant >> updateResize [
 
-	name vResizing: #shrinkWrap.
-	widget lastSubmorph vResizing: #spaceFill.
-	widget lastSubmorph hResizing: #spaceFill.
-	self vResizing: #shrinkWrap.
+	self hResizing: #shrinkWrap.
+	name hResizing: #spaceFill
 	
-	" mark a change"
-	self flag: #todo. "replace with proper undo commands in tab view -jb"
-	"self sandblockEditor do: (SBDoItCommand new artefact: self parentSandblock)."
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBVariant >> widget [
 
 	^ widget
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
+SBVariant >> widget: aSBTabView [
+
+	
+	widget := aSBTabView.
+	
+	widget when: #deletedLastTab send: #replaceSelfWithBlock: to: self.
+	widget when: #changedActive send: #updateResize to: self
+]
+
+{ #category : #printing }
 SBVariant >> writeSourceOn: aStream [
 
 	aStream nextPutAll: '(SBVariant named: '.

--- a/packages/Sandblocks-Smalltalk/SBVariant.class.st
+++ b/packages/Sandblocks-Smalltalk/SBVariant.class.st
@@ -120,7 +120,8 @@ SBVariant >> initialize [
 	
 	name := SBTextBubble new
 		contents: 'variant X';
-		layoutInset: 5 @ 5.
+		layoutInset: 5 @ 5;
+		font: (TextStyle default fontOfSize: 8.0 sbScaled).
 	widget := SBTabView
 		namedBlocks: {SBNamedBlock block: (SBStBlockBody emptyWithDeclarations: {'a'. 'c'}) named: 'Code'}
 		activeIndex: 1.

--- a/packages/Sandblocks-Smalltalk/SBVariant.class.st
+++ b/packages/Sandblocks-Smalltalk/SBVariant.class.st
@@ -1,0 +1,185 @@
+Class {
+	#name : #SBVariant,
+	#superclass : #SBStSubstitution,
+	#instVars : [
+		'name',
+		'widget'
+	],
+	#category : #'Sandblocks-Smalltalk'
+}
+
+{ #category : #'as yet unclassified' }
+SBVariant class >> example [
+
+	SBMorphExample
+		setUp: [self new]
+		cases: {SBMorphExampleCase name: 'example 1' caseBlock: [:m | m]}
+		extent: 300 @ 300
+]
+
+{ #category : #'as yet unclassified' }
+SBVariant class >> instanceSuggestion [
+
+	^ [self newEmpty]
+]
+
+{ #category : #'as yet unclassified' }
+SBVariant class >> matches: aBlock [
+
+	(super matches: aBlock) ifFalse: [^ false].
+	
+	^ aBlock receiver isBinding
+		and: [aBlock receiver contents = 'SBVariant']
+		and: [aBlock selector = 'named:associations:do:']
+]
+
+{ #category : #nil }
+SBVariant class >> named: aString alternatives: aCollectionOfNamedBlocks activeIndex: aNumber [
+
+	^ self new
+		name: aString;
+		alternatives: aCollectionOfNamedBlocks;
+		activeIndex: aNumber
+		
+]
+
+{ #category : #nil }
+SBVariant class >> named: aString associations: aCollectionOfAssociations activeIndex: aNumber [
+
+	^ aNumber > 0 ifTrue: [(aCollectionOfAssociations at: aNumber) value value] ifFalse: [nil]
+		
+]
+
+{ #category : #'as yet unclassified' }
+SBVariant class >> newEmpty [
+
+	^ self new
+]
+
+{ #category : #'as yet unclassified' }
+SBVariant class >> newFor: aBlock [
+
+	^ self
+		named: aBlock arguments first contents
+		alternatives: (aBlock arguments second childSandblocks collect: [:anAssociation | SBNamedBlock block: (anAssociation arguments first) named: (anAssociation receiver contents)])
+		activeIndex: aBlock arguments third parsedContents
+]
+
+{ #category : #'as yet unclassified' }
+SBVariant >> active [
+
+	^ self widget active
+]
+
+{ #category : #'as yet unclassified' }
+SBVariant >> activeBlock [
+
+	^ self widget activeBlock
+]
+
+{ #category : #'as yet unclassified' }
+SBVariant >> activeIndex [
+
+	^ self widget activeIndex
+]
+
+{ #category : #'as yet unclassified' }
+SBVariant >> activeIndex: aNumber [
+
+	^ self widget activeIndex: aNumber
+]
+
+{ #category : #'as yet unclassified' }
+SBVariant >> alternatives [
+
+	^ self widget namedBlocks
+]
+
+{ #category : #'as yet unclassified' }
+SBVariant >> alternatives: aCollectionOfNamedBlocks [
+
+	self widget namedBlocks: aCollectionOfNamedBlocks
+]
+
+{ #category : #'as yet unclassified' }
+SBVariant >> color [
+
+	^ Color transparent
+]
+
+{ #category : #'as yet unclassified' }
+SBVariant >> drawnColor [
+
+	^ Color white
+]
+
+{ #category : #'as yet unclassified' }
+SBVariant >> initialize [
+
+	super initialize.
+	
+	name := SBTextBubble new
+		contents: 'variant X';
+		layoutInset: 5 @ 5.
+	widget := SBTabView
+		namedBlocks: {SBNamedBlock block: (SBStBlockBody emptyWithDeclarations: {'a'. 'c'}) named: 'Code'}
+		activeIndex: 1.
+	
+	self
+		layoutInset: 2;
+		cellGap: 4;
+		vResizing: #shrinkWrap;
+		hResizing: #shrinkWrap;
+		changeTableLayout;
+		listDirection: #topToBottom;
+		addAllMorphsBack: {name. widget}
+]
+
+{ #category : #'as yet unclassified' }
+SBVariant >> name [
+
+	^ name contents
+]
+
+{ #category : #'as yet unclassified' }
+SBVariant >> name: aString [
+	name contents: aString
+]
+
+{ #category : #'as yet unclassified' }
+SBVariant >> named: aString alternatives: aCollectionOfNamedBlocks activeIndex: aNumber [
+
+	self name: aString.
+	self widget namedBlocks: aCollectionOfNamedBlocks activeIndex: aNumber
+]
+
+{ #category : #'as yet unclassified' }
+SBVariant >> namedBlocks [ 
+
+	^ self widget namedBlocks 
+]
+
+{ #category : #'as yet unclassified' }
+SBVariant >> widget [
+
+	^ widget
+]
+
+{ #category : #'as yet unclassified' }
+SBVariant >> writeSourceOn: aStream [
+
+	aStream nextPutAll: '(SBVariant named: '.
+	self name storeOn: aStream.
+	aStream nextPutAll: ' associations: {'.
+	self alternatives
+		do: [:aNamedBlock |
+			aNamedBlock name storeOn: aStream.
+			aStream nextPutAll: ' -> ['.
+			aNamedBlock block lastSubmorph writeSourceOn: aStream.
+			aStream nextPut: $].
+			]
+		separatedBy: [aStream nextPut: $.].
+	aStream nextPutAll: '} activeIndex: '.
+	self activeIndex storeOn: aStream.
+	aStream nextPutAll: ')'
+]

--- a/packages/Sandblocks-Smalltalk/SBVariant.class.st
+++ b/packages/Sandblocks-Smalltalk/SBVariant.class.st
@@ -125,6 +125,8 @@ SBVariant >> initialize [
 		namedBlocks: {SBNamedBlock block: (SBStBlockBody emptyWithDeclarations: {'a'. 'c'}) named: 'Code'}
 		activeIndex: 1.
 	
+	widget when: #deletedLastTab send: #replaceSelfWithChosenBlock: to: self.
+	
 	self
 		layoutInset: 2;
 		cellGap: 4;
@@ -157,6 +159,12 @@ SBVariant >> named: aString alternatives: aCollectionOfNamedBlocks activeIndex: 
 SBVariant >> namedBlocks [ 
 
 	^ self widget namedBlocks 
+]
+
+{ #category : #'as yet unclassified' }
+SBVariant >> replaceSelfWithChosenBlock: aNamedBlock [
+
+	self replaceBlock: aNamedBlock block lastSubmorph
 ]
 
 { #category : #'as yet unclassified' }

--- a/packages/Sandblocks-Smalltalk/SBVariant.class.st
+++ b/packages/Sandblocks-Smalltalk/SBVariant.class.st
@@ -14,7 +14,9 @@ SBVariant class >> example [
 	SBMorphExample
 		setUp: [self new]
 		cases: {SBMorphExampleCase name: 'example 1' caseBlock: [:m | m]}
-		extent: 300 @ 300
+		extent: 300 @ 300.
+	
+	
 ]
 
 { #category : #'as yet unclassified' }
@@ -37,8 +39,8 @@ SBVariant class >> matches: aBlock [
 SBVariant class >> named: aString alternatives: aCollectionOfNamedBlocks activeIndex: aNumber [
 
 	^ self new
-		name: aString;
-		alternatives: aCollectionOfNamedBlocks;
+		name: aString
+		alternatives: aCollectionOfNamedBlocks
 		activeIndex: aNumber
 		
 ]
@@ -66,6 +68,13 @@ SBVariant class >> newFor: aBlock [
 ]
 
 { #category : #'as yet unclassified' }
+SBVariant class >> registerShortcuts: aProvider [
+
+	aProvider registerShortcut: $f command do: #replaceSelfWithChosen.
+	
+]
+
+{ #category : #'as yet unclassified' }
 SBVariant >> active [
 
 	^ self widget active
@@ -84,21 +93,9 @@ SBVariant >> activeIndex [
 ]
 
 { #category : #'as yet unclassified' }
-SBVariant >> activeIndex: aNumber [
-
-	^ self widget activeIndex: aNumber
-]
-
-{ #category : #'as yet unclassified' }
 SBVariant >> alternatives [
 
 	^ self widget namedBlocks
-]
-
-{ #category : #'as yet unclassified' }
-SBVariant >> alternatives: aCollectionOfNamedBlocks [
-
-	self widget namedBlocks: aCollectionOfNamedBlocks
 ]
 
 { #category : #'as yet unclassified' }
@@ -114,48 +111,30 @@ SBVariant >> drawnColor [
 ]
 
 { #category : #'as yet unclassified' }
-SBVariant >> handlesMouseOver: anEvent [
-
-	^ true
-	
-]
-
-{ #category : #'as yet unclassified' }
 SBVariant >> initialize [
 
 	super initialize.
 	
-	name := SBTextBubble new
+	name := SBLabel new
 		contents: 'variant X';
-		layoutInset: 5 @ 5.
+		layoutInset: 5 @ 5;
+		vResizing: #shrinkWrap.
 	widget := SBTabView
 		namedBlocks: {SBNamedBlock block: (SBStBlockBody emptyWithDeclarations: {'a'. 'c'}) named: 'Code'}
 		activeIndex: 1.
 	
-	widget when: #deletedLastTab send: #replaceSelfWithChosenBlock: to: self.
+	widget when: #deletedLastTab send: #replaceSelfWithBlock: to: self.
+	widget when: #changedActive send: #updateResize to: self.
+	
 	
 	self
 		layoutInset: 0;
-		cellGap: 0;
+		cellGap: 2.0;
 		vResizing: #shrinkWrap;
 		hResizing: #shrinkWrap;
 		changeTableLayout;
-		listDirection: #topToBottom;
-		addAllMorphsBack: {widget}
-]
-
-{ #category : #'as yet unclassified' }
-SBVariant >> mouseEnter: anEvent [
-
-	super mouseEnter: anEvent.
-	self addMorphBack: name
-]
-
-{ #category : #'as yet unclassified' }
-SBVariant >> mouseLeave: anEvent [
-
-	super mouseLeave: anEvent.
-	self removeMorph: name
+		listDirection: #leftToRight;
+		addAllMorphsBack: {name. widget}
 ]
 
 { #category : #'as yet unclassified' }
@@ -183,9 +162,29 @@ SBVariant >> namedBlocks [
 ]
 
 { #category : #'as yet unclassified' }
-SBVariant >> replaceSelfWithChosenBlock: aNamedBlock [
-
+SBVariant >> replaceSelfWithBlock: aNamedBlock [
+	
 	self replaceBlock: aNamedBlock block lastSubmorph
+]
+
+{ #category : #'as yet unclassified' }
+SBVariant >> replaceSelfWithChosen [ 
+	
+	<action>
+	self replaceSelfWithBlock: self active
+]
+
+{ #category : #'as yet unclassified' }
+SBVariant >> updateResize [
+
+	name vResizing: #shrinkWrap.
+	widget lastSubmorph vResizing: #spaceFill.
+	widget lastSubmorph hResizing: #spaceFill.
+	self vResizing: #shrinkWrap.
+	
+	" mark a change"
+	self flag: #todo. "replace with proper undo commands in tab view -jb"
+	"self sandblockEditor do: (SBDoItCommand new artefact: self parentSandblock)."
 ]
 
 { #category : #'as yet unclassified' }


### PR DESCRIPTION
`SBVariants` are an enhanced option to `SBToggledCode` which work with any kind of sandblock. With an introduced `TabView`, similiar to browsers, users can choose one of multiple blocks which is displayed and executed. The tab has navigation, add and remove shortcuts. Furthermore, the actions are reversable commands. The tabs themselves are `SBNamedBlocks`, a new helper struct contained of a block and a name. 

![image](https://github.com/hpi-swa/sandblocks/assets/33000454/a1fcfa84-9b0d-4e20-bafd-0c361425d4be)
![image](https://github.com/hpi-swa/sandblocks/assets/33000454/a55f18ed-6fed-46f1-ba54-780c87e111e1)

