### PR TITLE
Several Exploriants Quality Of Lives 

### DIFF
--- a/packages/Sandblocks-Babylonian/SBExampleValueDisplay.class.st
+++ b/packages/Sandblocks-Babylonian/SBExampleValueDisplay.class.st
@@ -27,7 +27,9 @@ SBExampleValueDisplay >> exampleFinished: anExample [
 	display exampleFinished: anExample.
 	
 	statusLabel
-		contents: (hadValue ifTrue: [''] ifFalse: ['- Not reached -']);
+		contents: (hadValue 
+			ifTrue: [''] 
+			ifFalse: ['- Not reached -']);
 		visible: hadValue not
 ]
 

--- a/packages/Sandblocks-Babylonian/SBExampleWatch.class.st
+++ b/packages/Sandblocks-Babylonian/SBExampleWatch.class.st
@@ -123,7 +123,9 @@ SBExampleWatch >> artefactSaved: aBlock [
 { #category : #copying }
 SBExampleWatch >> asInactiveCopy [
 
-	^ (self veryDeepCopy) beInactive. 
+	^ self veryDeepCopy 
+		beInactive
+		setWatchedExpressionUneditable. 
 ]
 
 { #category : #accessing }
@@ -371,6 +373,12 @@ SBExampleWatch >> reportValue: anObject for: anExample [
 	exampleToValues
 		at: anExample
 		ifPresent: [:values | values add: anObject]
+]
+
+{ #category : #accessing }
+SBExampleWatch >> setWatchedExpressionUneditable [
+
+	watchedExpression selectable: false
 ]
 
 { #category : #accessing }

--- a/packages/Sandblocks-Babylonian/SBExampleWatch.class.st
+++ b/packages/Sandblocks-Babylonian/SBExampleWatch.class.st
@@ -1,5 +1,5 @@
 "
-Observes (watches) an expression locally for added SBExamples. Whenever an example has finished running, it updates its belonging view. Only active watches update their views. Further, with a given modifyExpression, it transforms the watched expression values. Also known as a Probe in the context of Babylonian Smalltalk.
+Observes (watches) an expression locally for added SBExamples. Whenever an example has finished running, it updates its belonging view. Further, with a given modifyExpression, it transforms the watched expression values. Also known as a Probe in the context of Babylonian Smalltalk.
 "
 Class {
 	#name : #SBExampleWatch,
@@ -8,7 +8,6 @@ Class {
 		'identifier',
 		'watchedExpression',
 		'modifyExpression',
-		'isActive',
 		'exampleToDisplay',
 		'exampleToValues'
 	],
@@ -112,31 +111,10 @@ SBExampleWatch >> applyModifyExpressionOnValues [
 		anExampleDisplayPair value updateDisplay]
 ]
 
-{ #category : #callbacks }
-SBExampleWatch >> artefactSaved: aBlock [
-
-	"As we are inactive, we have to manually apply our modifyExpression if it changes. 
-	Otherwise, we would reset by examples starting" 
-	(self isActive not and: [aBlock = self containingArtefact]) ifTrue: [self applyModifyExpressionOnValues] 
-]
-
 { #category : #copying }
 SBExampleWatch >> asInactiveCopy [
 
-	| copy |
-	copy := self veryDeepCopy beInactive.
-		
-	"Resolve bindings"
-	copy expression: (SBTextBubble new contents: copy expression sourceString).
-	copy setWatchedExpressionUneditable.
-
-	^ copy
-]
-
-{ #category : #accessing }
-SBExampleWatch >> beInactive [
-
-	isActive := false
+	^ SBInactiveExampleWatch newFromWatch: self
 ]
 
 { #category : #'colors and color policies' }
@@ -253,7 +231,6 @@ SBExampleWatch >> initialize [
 	exampleToValues := Dictionary new.
 	watchedExpression := SBStMessageSend new.
 	modifyExpression := SBStBlockBody identityNamed: 'result'.
-	isActive := true.
 	
 	self
 		cellGap: 4;
@@ -275,7 +252,7 @@ SBExampleWatch >> intoWorld: aWorld [
 { #category : #accessing }
 SBExampleWatch >> isActive [
 
-	^ isActive
+	^ true
 ]
 
 { #category : #'*Sandblocks-Babylonian' }
@@ -314,7 +291,7 @@ SBExampleWatch >> layoutCommands [
 { #category : #'*Sandblocks-Babylonian' }
 SBExampleWatch >> listensToExamples [
 
-	^ self isActive 
+	^ true
 ]
 
 { #category : #accessing }

--- a/packages/Sandblocks-Babylonian/SBExampleWatch.class.st
+++ b/packages/Sandblocks-Babylonian/SBExampleWatch.class.st
@@ -123,9 +123,14 @@ SBExampleWatch >> artefactSaved: aBlock [
 { #category : #copying }
 SBExampleWatch >> asInactiveCopy [
 
-	^ self veryDeepCopy 
-		beInactive
-		setWatchedExpressionUneditable. 
+	| copy |
+	copy := self veryDeepCopy beInactive.
+		
+	"Resolve bindings"
+	copy expression: (SBTextBubble new contents: copy expression sourceString).
+	copy setWatchedExpressionUneditable.
+
+	^ copy
 ]
 
 { #category : #accessing }

--- a/packages/Sandblocks-Babylonian/SBExampleWatch.class.st
+++ b/packages/Sandblocks-Babylonian/SBExampleWatch.class.st
@@ -209,7 +209,7 @@ SBExampleWatch >> exampleToValues: anExampleToCollectionOfObjectsDict [
 { #category : #accessing }
 SBExampleWatch >> expression [
 
-	^ watchedExpression
+	^ self submorphs first
 ]
 
 { #category : #accessing }

--- a/packages/Sandblocks-Babylonian/SBExampleWatch.class.st
+++ b/packages/Sandblocks-Babylonian/SBExampleWatch.class.st
@@ -70,7 +70,7 @@ SBExampleWatch class >> registry [
 SBExampleWatch class >> report: aValue for: aSymbol [
 
 	"Compatibility to SBWatch"
-	^ self reportValue: aValue for: aSymbol modifying: (SBStBlockBody identityNamed: 'result').
+	^ self reportValue: aValue for: aSymbol modifying: (SBStBlockBody identityNamed: 'each').
 ]
 
 { #category : #'event handling' }
@@ -230,7 +230,7 @@ SBExampleWatch >> initialize [
 	exampleToDisplay := Dictionary new.
 	exampleToValues := Dictionary new.
 	watchedExpression := SBStMessageSend new.
-	modifyExpression := SBStBlockBody identityNamed: 'result'.
+	modifyExpression := SBStBlockBody identityNamed: 'each'.
 	
 	self
 		cellGap: 4;

--- a/packages/Sandblocks-Babylonian/SBExampleWatch.extension.st
+++ b/packages/Sandblocks-Babylonian/SBExampleWatch.extension.st
@@ -15,5 +15,5 @@ SBExampleWatch >> isGlobalWatch [
 { #category : #'*Sandblocks-Babylonian' }
 SBExampleWatch >> listensToExamples [
 
-	^ self isActive 
+	^ true
 ]

--- a/packages/Sandblocks-Babylonian/SBInactiveExampleWatch.class.st
+++ b/packages/Sandblocks-Babylonian/SBInactiveExampleWatch.class.st
@@ -30,7 +30,7 @@ SBInactiveExampleWatch >> doubleClick: evt [
 	"Nothing"
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBInactiveExampleWatch >> expression: aBlock [
 
 	super expression: aBlock.

--- a/packages/Sandblocks-Babylonian/SBInactiveExampleWatch.class.st
+++ b/packages/Sandblocks-Babylonian/SBInactiveExampleWatch.class.st
@@ -1,0 +1,50 @@
+"
+Does not update its results anymore. Applying modification expressions is still possible.
+"
+Class {
+	#name : #SBInactiveExampleWatch,
+	#superclass : #SBExampleWatch,
+	#category : #'Sandblocks-Babylonian'
+}
+
+{ #category : #'initialize-release' }
+SBInactiveExampleWatch class >> newFromWatch: anActiveWatch [
+
+	^ (anActiveWatch veryDeepCopy)
+		primitiveChangeClassTo: self basicNew;
+		expression: (SBTextBubble new contents: anActiveWatch expression sourceString);
+		yourself 
+]
+
+{ #category : #callbacks }
+SBInactiveExampleWatch >> artefactSaved: aBlock [
+
+	"As we are inactive, we have to manually apply our modifyExpression if it changes. 
+	Otherwise, we would reset by examples starting" 
+	(aBlock = self containingArtefact) ifTrue: [self applyModifyExpressionOnValues] 
+]
+
+{ #category : #'event handling' }
+SBInactiveExampleWatch >> doubleClick: evt [
+	
+	"Nothing"
+]
+
+{ #category : #'as yet unclassified' }
+SBInactiveExampleWatch >> expression: aBlock [
+
+	super expression: aBlock.
+	watchedExpression selectable: false
+]
+
+{ #category : #accessing }
+SBInactiveExampleWatch >> isActive [
+
+	^ false
+]
+
+{ #category : #'*Sandblocks-Babylonian' }
+SBInactiveExampleWatch >> listensToExamples [
+
+	^ false
+]

--- a/packages/Sandblocks-Babylonian/SBInactiveExampleWatch.extension.st
+++ b/packages/Sandblocks-Babylonian/SBInactiveExampleWatch.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #SBInactiveExampleWatch }
+
+{ #category : #'*Sandblocks-Babylonian' }
+SBInactiveExampleWatch >> listensToExamples [
+
+	^ false
+]

--- a/packages/Sandblocks-Babylonian/SBResultsView.class.st
+++ b/packages/Sandblocks-Babylonian/SBResultsView.class.st
@@ -7,9 +7,7 @@ Class {
 { #category : #building }
 SBResultsView >> addAllWatchesFrom: aCollectionOfMethodBlocks [
 
-	self block addAllMorphsBack: { 	(self containerRow listDirection: #leftToRight) 
-										addAllMorphsBack: (self allWatchesIn: aCollectionOfMethodBlocks).
-									LineMorph from: 0@0 to: 50@0 color: Color black width: 2}
+	self block addAllMorphsBack: (self allWatchesIn: aCollectionOfMethodBlocks)
 ]
 
 { #category : #accessing }

--- a/packages/Sandblocks-Babylonian/SBResultsView.class.st
+++ b/packages/Sandblocks-Babylonian/SBResultsView.class.st
@@ -4,6 +4,14 @@ Class {
 	#category : #'Sandblocks-Babylonian'
 }
 
+{ #category : #building }
+SBResultsView >> addAllWatchesFrom: aCollectionOfMethodBlocks [
+
+	self block addAllMorphsBack: { 	(self containerRow listDirection: #leftToRight) 
+										addAllMorphsBack: (self allWatchesIn: aCollectionOfMethodBlocks).
+									LineMorph from: 0@0 to: 50@0 color: Color black width: 2}
+]
+
 { #category : #accessing }
 SBResultsView >> allActiveExamples [
 	
@@ -64,6 +72,8 @@ SBResultsView >> buildAllPossibleResults [
 	watchMethodBlocks := self allMethodBlocksContainingWatches.
 	activeExamples := self allActiveExamples.
 	permutations := SBPermutation allPermutationsOf: variants.
+	
+	permutations ifEmpty: [self addAllWatchesFrom: watchMethodBlocks].
 	
 	[ permutations do: [:aPermutation |
 		SBActiveVariantPermutation value: aPermutation.

--- a/packages/Sandblocks-Babylonian/SBVariantsView.class.st
+++ b/packages/Sandblocks-Babylonian/SBVariantsView.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #building }
 SBVariantsView >> buildMethodSectionFor: aSBStMethod [
 	
-	self block addAllMorphsBack: {aSBStMethod methodHeader copy.
+	self block addAllMorphsBack: {aSBStMethod methodDefinition.
 									self containerRow 
 										addAllMorphsBack: (aSBStMethod containedVariants collect: #asProxy).
 									LineMorph from: 0@0 to: 50@0 color: Color black width: 2}
@@ -35,6 +35,6 @@ SBVariantsView >> visualize [
 	self clean.
 
 	self allMethodBlocksContainingVariants 
-		ifNotEmptyDo: [:aSBStMethod | self buildMethodSectionFor: aSBStMethod] 
+		ifNotEmptyDo: [:theMethods | theMethods do: [:aSBStMethod | self buildMethodSectionFor: aSBStMethod]] 
 		ifEmpty: [self buildNoVariantsText]
 ]

--- a/packages/Sandblocks-Babylonian/SBVariantsView.class.st
+++ b/packages/Sandblocks-Babylonian/SBVariantsView.class.st
@@ -13,6 +13,12 @@ SBVariantsView >> buildMethodSectionFor: aSBStMethod [
 									LineMorph from: 0@0 to: 50@0 color: Color black width: 2}
 ]
 
+{ #category : #building }
+SBVariantsView >> buildNoVariantsText [
+	
+	self block addMorphBack: (SBOwnTextMorph new contents: 'No variants exist.')
+]
+
 { #category : #initialization }
 SBVariantsView >> initialize [ 
 
@@ -28,5 +34,7 @@ SBVariantsView >> visualize [
 
 	self clean.
 
-	self allMethodBlocksContainingVariants do: [:aSBStMethod | self buildMethodSectionFor: aSBStMethod]
+	self allMethodBlocksContainingVariants 
+		ifNotEmptyDo: [:aSBStMethod | self buildMethodSectionFor: aSBStMethod] 
+		ifEmpty: [self buildNoVariantsText]
 ]

--- a/packages/Sandblocks-Babylonian/SBWatchValueBlock.class.st
+++ b/packages/Sandblocks-Babylonian/SBWatchValueBlock.class.st
@@ -16,7 +16,7 @@ SBWatchValueBlock class >> registerShortcuts: aProvider [
 	
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'event handling' }
 SBWatchValueBlock >> doubleClick: evt [
 
 	super doubleClick: evt.
@@ -25,7 +25,7 @@ SBWatchValueBlock >> doubleClick: evt [
 
 { #category : #accessing }
 SBWatchValueBlock >> exploreValue [
-<action>
+	<action>
 
 	self watchValue watchedValue explore
 ]

--- a/packages/Sandblocks-Core/SBLabel.class.st
+++ b/packages/Sandblocks-Core/SBLabel.class.st
@@ -213,6 +213,14 @@ SBLabel >> symbols [
 ]
 
 { #category : #'as yet unclassified' }
+SBLabel >> text: aSBOwnTextMorph [
+
+	text ifNotNil: [text abandon]. 
+	text := aSBOwnTextMorph.
+	self addMorphBack: text.
+]
+
+{ #category : #'as yet unclassified' }
 SBLabel >> textBlock: aBlock [
 
 	self label: (Compiler evaluate: aBlock sourceString) value

--- a/packages/Sandblocks-Core/SBTabView.class.st
+++ b/packages/Sandblocks-Core/SBTabView.class.st
@@ -156,6 +156,7 @@ SBTabView >> asTabButton: aNamedBlock [
 	
 	aNamedBlock = self active ifTrue: [button makeBold].
 	button when: #contentsChanged send: #updateNameFor:on: to: self withArguments: {aNamedBlock. button}.
+	button when: #doubleClicked send: #triggerEvent: to: self with: #doubleClicked.
 	
 	^ button
 ]

--- a/packages/Sandblocks-Core/SBTextBubble.class.st
+++ b/packages/Sandblocks-Core/SBTextBubble.class.st
@@ -130,6 +130,12 @@ SBTextBubble >> font: aFont [
 ]
 
 { #category : #'as yet unclassified' }
+SBTextBubble >> guessedClass [ 
+
+	^ nil
+]
+
+{ #category : #'as yet unclassified' }
 SBTextBubble >> initialize [
 
 	super initialize.
@@ -207,7 +213,7 @@ SBTextBubble >> prefix: aString [
 { #category : #'as yet unclassified' }
 SBTextBubble >> printOn: aStream [
 
-	aStream nextPutAll: 'text bubble'
+	aStream nextPutAll: (self contents ifNil: ['text bubble'] ifNotNil: [self contents])
 ]
 
 { #category : #'as yet unclassified' }

--- a/packages/Sandblocks-Morphs/SBEditableButton.class.st
+++ b/packages/Sandblocks-Morphs/SBEditableButton.class.st
@@ -14,6 +14,10 @@ SBEditableButton >> textMorphFor: aString [
 		when: #clicked
 		send: #doButtonAction  
 		to: self;
+		when: #doubleClicked
+		send: #triggerEvent:
+		to: self
+		with: #doubleClicked;
 		when: #contentsChanged
 		send: #triggerEvent:
 		to: self

--- a/packages/Sandblocks-Smalltalk/SBStASTNode.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStASTNode.class.st
@@ -24,7 +24,7 @@ SBStASTNode class >> preferredColor [
 SBStASTNode class >> registerShortcuts: aProvider [
 
 	aProvider
-		cmdShortcut: $" do: #wrapInToggledCode;
+		cmdShortcut: $" do: #wrapInOptionalVariant;
 		cmdShortcut: $Q do: #wrapInVariant;
 		noInsertShortcut: $[ do: #wrapInBlock;
 		noInsertShortcut: ${ do: #wrapInDynamicArray;

--- a/packages/Sandblocks-Smalltalk/SBStGrammarHandler.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStGrammarHandler.class.st
@@ -514,6 +514,29 @@ SBStGrammarHandler >> wrapInMessageSend: aString [
 ]
 
 { #category : #actions }
+SBStGrammarHandler >> wrapInOptionalVariant [
+	<multiSelectAction>
+	<actionValidIf: #isSandblock>
+
+	| variant |
+	self assert: self block isSelected.
+	variant := SBVariant new.
+	self block sandblockEditor multiSelectionIsConsecutive ifFalse: [^ self].
+	self block sandblockEditor doMultiSelection: [:selected |
+		SBWrapConsecutiveCommand new
+			selectAfter: #block;
+			outer: variant;
+			targets: selected;
+			wrap: [:outer :inner | 
+				variant 
+					named: inner printString 
+					alternatives:{
+						SBNamedBlock block: (SBStBlockBody new statements: inner) named:'with'. 
+						SBNamedBlock block: (SBStBlockBody empty) named:'without'} 					activeIndex: 2];
+			yourself]
+]
+
+{ #category : #actions }
 SBStGrammarHandler >> wrapInReturn [
 	<action>
 

--- a/packages/Sandblocks-Smalltalk/SBStGrammarHandler.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStGrammarHandler.class.st
@@ -582,7 +582,12 @@ SBStGrammarHandler >> wrapInVariant [
 			selectAfter: #block;
 			outer: variant;
 			targets: selected;
-			wrap: [:outer :inner | variant named: inner printString alternatives:{SBNamedBlock block: (SBStBlockBody new statements: inner) named:'alt'} activeIndex: 1];
+			wrap: [:outer :inner | variant 
+				named: inner printString 
+				alternatives: {
+					SBNamedBlock block: (SBStBlockBody new statements: inner) named: 'original'.
+					SBNamedBlock block: (SBStBlockBody new statements: inner veryDeepCopy) named: 'alternative'. } 
+				activeIndex: 2];
 			yourself]
 ]
 

--- a/packages/Sandblocks-Smalltalk/SBStMethod.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStMethod.class.st
@@ -145,9 +145,15 @@ SBStMethod >> methodClass [
 ]
 
 { #category : #accessing }
-SBStMethod >> methodHeader [
+SBStMethod >> methodDefinition [
 
-	^ self firstSubmorph 
+	^  SBRow new
+			layoutPolicy: SBAlgebraLayout new;
+			addMorphBack: (SBOwnTextMorph new contents: 
+				('{1} >> {2}' 
+					format: {
+					self currentClass name asString.
+					self currentSelector asString})).
 ]
 
 { #category : #'object interface' }

--- a/packages/Sandblocks-Smalltalk/SBVariant.class.st
+++ b/packages/Sandblocks-Smalltalk/SBVariant.class.st
@@ -314,7 +314,8 @@ SBVariant >> widget: aSBTabView [
 	widget := aSBTabView.
 	
 	widget when: #deletedLastTab send: #replaceSelfWithBlock: to: self.
-	widget when: #changedActive send: #updateResize to: self
+	widget when: #changedActive send: #updateResize to: self.
+	widget when: #doubleClicked send: #replaceSelfWithChosen to: self.
 ]
 
 { #category : #printing }

--- a/packages/Sandblocks-Smalltalk/SBVariant.class.st
+++ b/packages/Sandblocks-Smalltalk/SBVariant.class.st
@@ -193,9 +193,10 @@ SBVariant >> initialize [
 	super initialize.
 	
 	name := SBLabel new
-		contents: 'variant X';
-		layoutInset: 5 @ 5;
-		hResizing: #spaceFill.
+		text: (SBOwnTextMorph new
+			emphasis: TextEmphasis italic;
+			small);
+		contents: 'Variant X'.
 	self widget: (SBTabView
 		namedBlocks: {SBNamedBlock block: (SBStBlockBody emptyWithDeclarations: {'a'. 'c'}) named: 'Code'}
 		activeIndex: 1).
@@ -206,7 +207,7 @@ SBVariant >> initialize [
 		cellGap: 2.0;
 		listDirection: #topToBottom;
 		changeTableLayout;
-		addAllMorphsBack: {name. widget};
+		addAllMorphsBack: {name . widget};
 		vResizing: #shrinkWrap;
 		hResizing: #shrinkWrap
 ]
@@ -225,6 +226,7 @@ SBVariant >> name [
 
 { #category : #accessing }
 SBVariant >> name: aString [
+
 	name contents: aString
 ]
 

--- a/packages/Sandblocks-Utils/SBPermutation.class.st
+++ b/packages/Sandblocks-Utils/SBPermutation.class.st
@@ -15,6 +15,7 @@ Class {
 SBPermutation class >> allPermutationsOf: aCollectionOfVariants [
 
 	| permutations |
+	aCollectionOfVariants ifEmpty:[^#()].
 	permutations := (1 to: aCollectionOfVariants first alternativesCount) collect: #asArray.
 	
 	(2 to: aCollectionOfVariants size) do: [:i | | alternatives |

--- a/packages/Sandblocks-Watch/SBWatchView.class.st
+++ b/packages/Sandblocks-Watch/SBWatchView.class.st
@@ -125,10 +125,24 @@ SBWatchView >> displayWatchValues [
 		ifFalse: [self maxWidth]).
 ]
 
+{ #category : #'event handling' }
+SBWatchView >> doubleClick: evt [
+
+	super doubleClick: evt.
+	self exploreValues
+]
+
 { #category : #'colors and color policies' }
 SBWatchView >> drawnColor [
 
 	^ Color white
+]
+
+{ #category : #accessing }
+SBWatchView >> exploreValues [
+	<action>
+
+	self object explore
 ]
 
 { #category : #accessing }
@@ -183,7 +197,7 @@ SBWatchView >> layoutCommands [
 { #category : #accessing }
 SBWatchView >> maxWidth [
 
-	^ 450
+	^ 300
 ]
 
 { #category : #accessing }
@@ -202,7 +216,9 @@ SBWatchView >> object [
 { #category : #'event handling' }
 SBWatchView >> placeholder [
 
-	^  Morph new color: Color transparent; extent: (0@0)
+	^  Morph new 
+		color: Color transparent; 
+		extent: (0@0)
 ]
 
 { #category : #printing }
@@ -330,5 +346,6 @@ SBWatchView >> watchValuesContainer [
 		changeTableLayout;
 		listDirection: #leftToRight;
 		layoutInset: 1;
-		borderWidth: 0
+		borderWidth: 0;
+		on: #doubleClick send: #exploreValues to: self
 ]

--- a/packages/Sandblocks-Watch/SBWatchView.class.st
+++ b/packages/Sandblocks-Watch/SBWatchView.class.st
@@ -51,7 +51,7 @@ SBWatchView >> changeDisplay [
 	index := UIManager default chooseFrom: (options collect: #first).
 	index = 0 ifTrue: [^ self].
 	
-	self useDisplay: (options at: index) second
+	self displayOnScrollPane: (options at: index) second.
 ]
 
 { #category : #'event handling' }
@@ -110,19 +110,27 @@ SBWatchView >> display [
 ]
 
 { #category : #display }
+SBWatchView >> displayOnScrollPane: aMorph [
+
+	self scroller removeAllMorphs.
+	
+	self scroller addMorph: aMorph.
+	self scrollPane height: aMorph height + self scrollBarHeight.
+	
+	"Simulates an expanding layout"
+	self scrollPane width: (aMorph width <= self maxWidth 
+		ifTrue: [aMorph width] 
+		ifFalse: [self maxWidth])
+]
+
+{ #category : #display }
 SBWatchView >> displayWatchValues [
 
 	| valuesMorph |
-	self scroller removeAllMorphs.
 	valuesMorph := self watchValuesContainer.
 	watchValues do: [:aValue | valuesMorph addMorphBack: (aValue asValueMorph)].
 
-	self scroller addMorph: valuesMorph.
-	self scrollPane height: valuesMorph height + self scrollBarHeight.
-	"Simulates an expanding layout"
-	self scrollPane width: (valuesMorph width <= self maxWidth 
-		ifTrue: [valuesMorph width] 
-		ifFalse: [self maxWidth]).
+	self displayOnScrollPane: valuesMorph.
 ]
 
 { #category : #'event handling' }
@@ -292,13 +300,6 @@ SBWatchView >> updateDisplay [
 			visible: true].
 		
 	self displayWatchValues
-]
-
-{ #category : #display }
-SBWatchView >> useDisplay: aDisplay [
-
-	self display delete.
-	self addMorph: aDisplay atIndex: 2. 
 ]
 
 { #category : #accessing }

--- a/packages/Sandblocks-Watch/SBWatchView.class.st
+++ b/packages/Sandblocks-Watch/SBWatchView.class.st
@@ -129,7 +129,7 @@ SBWatchView >> displayWatchValues [
 
 	| valuesMorph |
 	valuesMorph := self watchValuesContainer.
-	watchValues do: [:aValue | valuesMorph addMorphBack: (aValue asValueMorph)].
+	valuesMorph addAllMorphsBack: (watchValues collect: #asValueMorph).
 
 	self displayOnScrollPane: valuesMorph.
 ]

--- a/packages/Sandblocks-Watch/SBWatchView.class.st
+++ b/packages/Sandblocks-Watch/SBWatchView.class.st
@@ -47,7 +47,8 @@ SBWatchView >> changeDisplay [
 	<action>
 
 	| index options |
-	options := Array streamContents: [:stream | self values allConversionsFor: SBInterfaces topLevel do: [:pair | stream nextPut: pair]].
+	options := Array streamContents: [:stream | self values allConversionsFor: SBInterfaces topLevel do: [:pair | stream nextPut: pair]]. 
+	options := options, {{'default'. self watchValuesContainer addAllMorphsBack: (watchValues collect: #asValueMorph)}}.
 	index := UIManager default chooseFrom: (options collect: #first).
 	index = 0 ifTrue: [^ self].
 	


### PR DESCRIPTION
* Inactive Watches' watched expressions not changeable
* SBVariants in SBWatches & Vice Versa
* Smaller SBVariants label
* Exploriants handles no variants
* Resolves Exploriants bindings
* Double click on watches & variants
* Shift + " now creates optional variant instead of toggled code
* warpInVariant automatically creates second alternative tab
* different displays in sbexamplewatches now use scrollpane