### PR TITLE
Graphs for Example Watches

### DIFF
--- a/packages/Sandblocks-Babylonian/SBExampleValueDisplay.class.st
+++ b/packages/Sandblocks-Babylonian/SBExampleValueDisplay.class.st
@@ -27,7 +27,9 @@ SBExampleValueDisplay >> exampleFinished: anExample [
 	display exampleFinished: anExample.
 	
 	statusLabel
-		contents: (hadValue ifTrue: [''] ifFalse: ['- Not reached -']);
+		contents: (hadValue 
+			ifTrue: [''] 
+			ifFalse: ['- Not reached -']);
 		visible: hadValue not
 ]
 

--- a/packages/Sandblocks-Babylonian/SBExampleWatch.class.st
+++ b/packages/Sandblocks-Babylonian/SBExampleWatch.class.st
@@ -123,7 +123,9 @@ SBExampleWatch >> artefactSaved: aBlock [
 { #category : #copying }
 SBExampleWatch >> asInactiveCopy [
 
-	^ (self veryDeepCopy) beInactive. 
+	^ self veryDeepCopy 
+		beInactive
+		setWatchedExpressionUneditable. 
 ]
 
 { #category : #accessing }
@@ -371,6 +373,12 @@ SBExampleWatch >> reportValue: anObject for: anExample [
 	exampleToValues
 		at: anExample
 		ifPresent: [:values | values add: anObject]
+]
+
+{ #category : #accessing }
+SBExampleWatch >> setWatchedExpressionUneditable [
+
+	watchedExpression selectable: false
 ]
 
 { #category : #accessing }

--- a/packages/Sandblocks-Babylonian/SBExampleWatch.class.st
+++ b/packages/Sandblocks-Babylonian/SBExampleWatch.class.st
@@ -1,5 +1,5 @@
 "
-Observes (watches) an expression locally for added SBExamples. Whenever an example has finished running, it updates its belonging view. Only active watches update their views. Further, with a given modifyExpression, it transforms the watched expression values. Also known as a Probe in the context of Babylonian Smalltalk.
+Observes (watches) an expression locally for added SBExamples. Whenever an example has finished running, it updates its belonging view. Further, with a given modifyExpression, it transforms the watched expression values. Also known as a Probe in the context of Babylonian Smalltalk.
 "
 Class {
 	#name : #SBExampleWatch,
@@ -8,7 +8,6 @@ Class {
 		'identifier',
 		'watchedExpression',
 		'modifyExpression',
-		'isActive',
 		'exampleToDisplay',
 		'exampleToValues'
 	],
@@ -112,31 +111,10 @@ SBExampleWatch >> applyModifyExpressionOnValues [
 		anExampleDisplayPair value updateDisplay]
 ]
 
-{ #category : #callbacks }
-SBExampleWatch >> artefactSaved: aBlock [
-
-	"As we are inactive, we have to manually apply our modifyExpression if it changes. 
-	Otherwise, we would reset by examples starting" 
-	(self isActive not and: [aBlock = self containingArtefact]) ifTrue: [self applyModifyExpressionOnValues] 
-]
-
 { #category : #copying }
 SBExampleWatch >> asInactiveCopy [
 
-	| copy |
-	copy := self veryDeepCopy beInactive.
-		
-	"Resolve bindings"
-	copy expression: (SBTextBubble new contents: copy expression sourceString).
-	copy setWatchedExpressionUneditable.
-
-	^ copy
-]
-
-{ #category : #accessing }
-SBExampleWatch >> beInactive [
-
-	isActive := false
+	^ SBInactiveExampleWatch newFromWatch: self
 ]
 
 { #category : #'colors and color policies' }
@@ -253,7 +231,6 @@ SBExampleWatch >> initialize [
 	exampleToValues := Dictionary new.
 	watchedExpression := SBStMessageSend new.
 	modifyExpression := SBStBlockBody identityNamed: 'result'.
-	isActive := true.
 	
 	self
 		cellGap: 4;
@@ -275,7 +252,7 @@ SBExampleWatch >> intoWorld: aWorld [
 { #category : #accessing }
 SBExampleWatch >> isActive [
 
-	^ isActive
+	^ true
 ]
 
 { #category : #'*Sandblocks-Babylonian' }
@@ -314,7 +291,7 @@ SBExampleWatch >> layoutCommands [
 { #category : #'*Sandblocks-Babylonian' }
 SBExampleWatch >> listensToExamples [
 
-	^ self isActive 
+	^ true
 ]
 
 { #category : #accessing }

--- a/packages/Sandblocks-Babylonian/SBExampleWatch.class.st
+++ b/packages/Sandblocks-Babylonian/SBExampleWatch.class.st
@@ -123,9 +123,14 @@ SBExampleWatch >> artefactSaved: aBlock [
 { #category : #copying }
 SBExampleWatch >> asInactiveCopy [
 
-	^ self veryDeepCopy 
-		beInactive
-		setWatchedExpressionUneditable. 
+	| copy |
+	copy := self veryDeepCopy beInactive.
+		
+	"Resolve bindings"
+	copy expression: (SBTextBubble new contents: copy expression sourceString).
+	copy setWatchedExpressionUneditable.
+
+	^ copy
 ]
 
 { #category : #accessing }

--- a/packages/Sandblocks-Babylonian/SBExampleWatch.class.st
+++ b/packages/Sandblocks-Babylonian/SBExampleWatch.class.st
@@ -209,7 +209,7 @@ SBExampleWatch >> exampleToValues: anExampleToCollectionOfObjectsDict [
 { #category : #accessing }
 SBExampleWatch >> expression [
 
-	^ watchedExpression
+	^ self submorphs first
 ]
 
 { #category : #accessing }

--- a/packages/Sandblocks-Babylonian/SBExampleWatch.extension.st
+++ b/packages/Sandblocks-Babylonian/SBExampleWatch.extension.st
@@ -15,5 +15,5 @@ SBExampleWatch >> isGlobalWatch [
 { #category : #'*Sandblocks-Babylonian' }
 SBExampleWatch >> listensToExamples [
 
-	^ self isActive 
+	^ true
 ]

--- a/packages/Sandblocks-Babylonian/SBInactiveExampleWatch.class.st
+++ b/packages/Sandblocks-Babylonian/SBInactiveExampleWatch.class.st
@@ -30,7 +30,7 @@ SBInactiveExampleWatch >> doubleClick: evt [
 	"Nothing"
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBInactiveExampleWatch >> expression: aBlock [
 
 	super expression: aBlock.

--- a/packages/Sandblocks-Babylonian/SBInactiveExampleWatch.class.st
+++ b/packages/Sandblocks-Babylonian/SBInactiveExampleWatch.class.st
@@ -1,0 +1,50 @@
+"
+Does not update its results anymore. Applying modification expressions is still possible.
+"
+Class {
+	#name : #SBInactiveExampleWatch,
+	#superclass : #SBExampleWatch,
+	#category : #'Sandblocks-Babylonian'
+}
+
+{ #category : #'initialize-release' }
+SBInactiveExampleWatch class >> newFromWatch: anActiveWatch [
+
+	^ (anActiveWatch veryDeepCopy)
+		primitiveChangeClassTo: self basicNew;
+		expression: (SBTextBubble new contents: anActiveWatch expression sourceString);
+		yourself 
+]
+
+{ #category : #callbacks }
+SBInactiveExampleWatch >> artefactSaved: aBlock [
+
+	"As we are inactive, we have to manually apply our modifyExpression if it changes. 
+	Otherwise, we would reset by examples starting" 
+	(aBlock = self containingArtefact) ifTrue: [self applyModifyExpressionOnValues] 
+]
+
+{ #category : #'event handling' }
+SBInactiveExampleWatch >> doubleClick: evt [
+	
+	"Nothing"
+]
+
+{ #category : #'as yet unclassified' }
+SBInactiveExampleWatch >> expression: aBlock [
+
+	super expression: aBlock.
+	watchedExpression selectable: false
+]
+
+{ #category : #accessing }
+SBInactiveExampleWatch >> isActive [
+
+	^ false
+]
+
+{ #category : #'*Sandblocks-Babylonian' }
+SBInactiveExampleWatch >> listensToExamples [
+
+	^ false
+]

--- a/packages/Sandblocks-Babylonian/SBInactiveExampleWatch.extension.st
+++ b/packages/Sandblocks-Babylonian/SBInactiveExampleWatch.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #SBInactiveExampleWatch }
+
+{ #category : #'*Sandblocks-Babylonian' }
+SBInactiveExampleWatch >> listensToExamples [
+
+	^ false
+]

--- a/packages/Sandblocks-Babylonian/SBResultsView.class.st
+++ b/packages/Sandblocks-Babylonian/SBResultsView.class.st
@@ -7,9 +7,7 @@ Class {
 { #category : #building }
 SBResultsView >> addAllWatchesFrom: aCollectionOfMethodBlocks [
 
-	self block addAllMorphsBack: { 	(self containerRow listDirection: #leftToRight) 
-										addAllMorphsBack: (self allWatchesIn: aCollectionOfMethodBlocks).
-									LineMorph from: 0@0 to: 50@0 color: Color black width: 2}
+	self block addAllMorphsBack: (self allWatchesIn: aCollectionOfMethodBlocks)
 ]
 
 { #category : #accessing }

--- a/packages/Sandblocks-Babylonian/SBResultsView.class.st
+++ b/packages/Sandblocks-Babylonian/SBResultsView.class.st
@@ -4,6 +4,14 @@ Class {
 	#category : #'Sandblocks-Babylonian'
 }
 
+{ #category : #building }
+SBResultsView >> addAllWatchesFrom: aCollectionOfMethodBlocks [
+
+	self block addAllMorphsBack: { 	(self containerRow listDirection: #leftToRight) 
+										addAllMorphsBack: (self allWatchesIn: aCollectionOfMethodBlocks).
+									LineMorph from: 0@0 to: 50@0 color: Color black width: 2}
+]
+
 { #category : #accessing }
 SBResultsView >> allActiveExamples [
 	
@@ -64,6 +72,8 @@ SBResultsView >> buildAllPossibleResults [
 	watchMethodBlocks := self allMethodBlocksContainingWatches.
 	activeExamples := self allActiveExamples.
 	permutations := SBPermutation allPermutationsOf: variants.
+	
+	permutations ifEmpty: [self addAllWatchesFrom: watchMethodBlocks].
 	
 	[ permutations do: [:aPermutation |
 		SBActiveVariantPermutation value: aPermutation.

--- a/packages/Sandblocks-Babylonian/SBVariantsView.class.st
+++ b/packages/Sandblocks-Babylonian/SBVariantsView.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #building }
 SBVariantsView >> buildMethodSectionFor: aSBStMethod [
 	
-	self block addAllMorphsBack: {aSBStMethod methodHeader copy.
+	self block addAllMorphsBack: {aSBStMethod methodDefinition.
 									self containerRow 
 										addAllMorphsBack: (aSBStMethod containedVariants collect: #asProxy).
 									LineMorph from: 0@0 to: 50@0 color: Color black width: 2}
@@ -35,6 +35,6 @@ SBVariantsView >> visualize [
 	self clean.
 
 	self allMethodBlocksContainingVariants 
-		ifNotEmptyDo: [:aSBStMethod | self buildMethodSectionFor: aSBStMethod] 
+		ifNotEmptyDo: [:theMethods | theMethods do: [:aSBStMethod | self buildMethodSectionFor: aSBStMethod]] 
 		ifEmpty: [self buildNoVariantsText]
 ]

--- a/packages/Sandblocks-Babylonian/SBVariantsView.class.st
+++ b/packages/Sandblocks-Babylonian/SBVariantsView.class.st
@@ -13,6 +13,12 @@ SBVariantsView >> buildMethodSectionFor: aSBStMethod [
 									LineMorph from: 0@0 to: 50@0 color: Color black width: 2}
 ]
 
+{ #category : #building }
+SBVariantsView >> buildNoVariantsText [
+	
+	self block addMorphBack: (SBOwnTextMorph new contents: 'No variants exist.')
+]
+
 { #category : #initialization }
 SBVariantsView >> initialize [ 
 
@@ -28,5 +34,7 @@ SBVariantsView >> visualize [
 
 	self clean.
 
-	self allMethodBlocksContainingVariants do: [:aSBStMethod | self buildMethodSectionFor: aSBStMethod]
+	self allMethodBlocksContainingVariants 
+		ifNotEmptyDo: [:aSBStMethod | self buildMethodSectionFor: aSBStMethod] 
+		ifEmpty: [self buildNoVariantsText]
 ]

--- a/packages/Sandblocks-Babylonian/SBWatchValueBlock.class.st
+++ b/packages/Sandblocks-Babylonian/SBWatchValueBlock.class.st
@@ -16,7 +16,7 @@ SBWatchValueBlock class >> registerShortcuts: aProvider [
 	
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'event handling' }
 SBWatchValueBlock >> doubleClick: evt [
 
 	super doubleClick: evt.
@@ -25,7 +25,7 @@ SBWatchValueBlock >> doubleClick: evt [
 
 { #category : #accessing }
 SBWatchValueBlock >> exploreValue [
-<action>
+	<action>
 
 	self watchValue watchedValue explore
 ]

--- a/packages/Sandblocks-Core/Collection.extension.st
+++ b/packages/Sandblocks-Core/Collection.extension.st
@@ -1,6 +1,15 @@
 Extension { #name : #Collection }
 
 { #category : #'*Sandblocks-Core-converting' }
+Collection >> asBarChart: converter [
+	<convert>
+	
+	converter
+		if: [self isString not and: [self isDictionary not and: [self allSatisfy: SBBarChart supportedInterface]]]
+		do: [SBBarChart newWithValues: self]
+]
+
+{ #category : #'*Sandblocks-Core-converting' }
 Collection >> asCollectionView: converter [
 	<convert>
 	

--- a/packages/Sandblocks-Core/Collection.extension.st
+++ b/packages/Sandblocks-Core/Collection.extension.st
@@ -9,6 +9,24 @@ Collection >> asCollectionView: converter [
 		do: [SBCollection new interface: converter objectInterface object: self]
 ]
 
+{ #category : #'*Sandblocks-Core-converting' }
+Collection >> asLineChart: converter [
+	<convert>
+	
+	converter
+		if: [self isString not and: [self isDictionary not and: [self allSatisfy: SBLineChart supportedInterface]]]
+		do: [SBLineChart newWithValues: self]
+]
+
+{ #category : #'*Sandblocks-Core-converting' }
+Collection >> asRectangleChart: converter [
+	<convert>
+	
+	converter
+		if: [self isString not and: [self isDictionary not and: [self allSatisfy: SBRectangleChart supportedInterface]]]
+		do: [SBRectangleChart newWithValues: self]
+]
+
 { #category : #'*Sandblocks-Core' }
 Collection >> asSandblockShortcut [
 

--- a/packages/Sandblocks-Core/SBLabel.class.st
+++ b/packages/Sandblocks-Core/SBLabel.class.st
@@ -213,6 +213,14 @@ SBLabel >> symbols [
 ]
 
 { #category : #'as yet unclassified' }
+SBLabel >> text: aSBOwnTextMorph [
+
+	text ifNotNil: [text abandon]. 
+	text := aSBOwnTextMorph.
+	self addMorphBack: text.
+]
+
+{ #category : #'as yet unclassified' }
 SBLabel >> textBlock: aBlock [
 
 	self label: (Compiler evaluate: aBlock sourceString) value

--- a/packages/Sandblocks-Core/SBTabView.class.st
+++ b/packages/Sandblocks-Core/SBTabView.class.st
@@ -156,6 +156,7 @@ SBTabView >> asTabButton: aNamedBlock [
 	
 	aNamedBlock = self active ifTrue: [button makeBold].
 	button when: #contentsChanged send: #updateNameFor:on: to: self withArguments: {aNamedBlock. button}.
+	button when: #doubleClicked send: #triggerEvent: to: self with: #doubleClicked.
 	
 	^ button
 ]

--- a/packages/Sandblocks-Core/SBTextBubble.class.st
+++ b/packages/Sandblocks-Core/SBTextBubble.class.st
@@ -130,6 +130,12 @@ SBTextBubble >> font: aFont [
 ]
 
 { #category : #'as yet unclassified' }
+SBTextBubble >> guessedClass [ 
+
+	^ nil
+]
+
+{ #category : #'as yet unclassified' }
 SBTextBubble >> initialize [
 
 	super initialize.
@@ -207,7 +213,7 @@ SBTextBubble >> prefix: aString [
 { #category : #'as yet unclassified' }
 SBTextBubble >> printOn: aStream [
 
-	aStream nextPutAll: 'text bubble'
+	aStream nextPutAll: (self contents ifNil: ['text bubble'] ifNotNil: [self contents])
 ]
 
 { #category : #'as yet unclassified' }

--- a/packages/Sandblocks-Morphs/SBEditableButton.class.st
+++ b/packages/Sandblocks-Morphs/SBEditableButton.class.st
@@ -14,6 +14,10 @@ SBEditableButton >> textMorphFor: aString [
 		when: #clicked
 		send: #doButtonAction  
 		to: self;
+		when: #doubleClicked
+		send: #triggerEvent:
+		to: self
+		with: #doubleClicked;
 		when: #contentsChanged
 		send: #triggerEvent:
 		to: self

--- a/packages/Sandblocks-Morphs/SBOwnTextMorph.class.st
+++ b/packages/Sandblocks-Morphs/SBOwnTextMorph.class.st
@@ -549,6 +549,12 @@ SBOwnTextMorph >> userString [
 ]
 
 { #category : #'as yet unclassified' }
+SBOwnTextMorph >> verySmall [
+
+	self font: (TextStyle default fontOfSize: 6 sbScaled)
+]
+
+{ #category : #'as yet unclassified' }
 SBOwnTextMorph >> wantsKeyboardFocus [
 
 	^ false

--- a/packages/Sandblocks-Smalltalk/SBStASTNode.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStASTNode.class.st
@@ -24,7 +24,7 @@ SBStASTNode class >> preferredColor [
 SBStASTNode class >> registerShortcuts: aProvider [
 
 	aProvider
-		cmdShortcut: $" do: #wrapInToggledCode;
+		cmdShortcut: $" do: #wrapInOptionalVariant;
 		cmdShortcut: $Q do: #wrapInVariant;
 		noInsertShortcut: $[ do: #wrapInBlock;
 		noInsertShortcut: ${ do: #wrapInDynamicArray;

--- a/packages/Sandblocks-Smalltalk/SBStGrammarHandler.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStGrammarHandler.class.st
@@ -514,6 +514,29 @@ SBStGrammarHandler >> wrapInMessageSend: aString [
 ]
 
 { #category : #actions }
+SBStGrammarHandler >> wrapInOptionalVariant [
+	<multiSelectAction>
+	<actionValidIf: #isSandblock>
+
+	| variant |
+	self assert: self block isSelected.
+	variant := SBVariant new.
+	self block sandblockEditor multiSelectionIsConsecutive ifFalse: [^ self].
+	self block sandblockEditor doMultiSelection: [:selected |
+		SBWrapConsecutiveCommand new
+			selectAfter: #block;
+			outer: variant;
+			targets: selected;
+			wrap: [:outer :inner | 
+				variant 
+					named: inner printString 
+					alternatives:{
+						SBNamedBlock block: (SBStBlockBody new statements: inner) named:'with'. 
+						SBNamedBlock block: (SBStBlockBody empty) named:'without'} 					activeIndex: 2];
+			yourself]
+]
+
+{ #category : #actions }
 SBStGrammarHandler >> wrapInReturn [
 	<action>
 

--- a/packages/Sandblocks-Smalltalk/SBStGrammarHandler.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStGrammarHandler.class.st
@@ -582,7 +582,12 @@ SBStGrammarHandler >> wrapInVariant [
 			selectAfter: #block;
 			outer: variant;
 			targets: selected;
-			wrap: [:outer :inner | variant named: inner printString alternatives:{SBNamedBlock block: (SBStBlockBody new statements: inner) named:'alt'} activeIndex: 1];
+			wrap: [:outer :inner | variant 
+				named: inner printString 
+				alternatives: {
+					SBNamedBlock block: (SBStBlockBody new statements: inner) named: 'original'.
+					SBNamedBlock block: (SBStBlockBody new statements: inner veryDeepCopy) named: 'alternative'. } 
+				activeIndex: 2];
 			yourself]
 ]
 

--- a/packages/Sandblocks-Smalltalk/SBStMethod.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStMethod.class.st
@@ -145,9 +145,15 @@ SBStMethod >> methodClass [
 ]
 
 { #category : #accessing }
-SBStMethod >> methodHeader [
+SBStMethod >> methodDefinition [
 
-	^ self firstSubmorph 
+	^  SBRow new
+			layoutPolicy: SBAlgebraLayout new;
+			addMorphBack: (SBOwnTextMorph new contents: 
+				('{1} >> {2}' 
+					format: {
+					self currentClass name asString.
+					self currentSelector asString})).
 ]
 
 { #category : #'object interface' }

--- a/packages/Sandblocks-Smalltalk/SBVariant.class.st
+++ b/packages/Sandblocks-Smalltalk/SBVariant.class.st
@@ -314,7 +314,8 @@ SBVariant >> widget: aSBTabView [
 	widget := aSBTabView.
 	
 	widget when: #deletedLastTab send: #replaceSelfWithBlock: to: self.
-	widget when: #changedActive send: #updateResize to: self
+	widget when: #changedActive send: #updateResize to: self.
+	widget when: #doubleClicked send: #replaceSelfWithChosen to: self.
 ]
 
 { #category : #printing }

--- a/packages/Sandblocks-Smalltalk/SBVariant.class.st
+++ b/packages/Sandblocks-Smalltalk/SBVariant.class.st
@@ -193,9 +193,10 @@ SBVariant >> initialize [
 	super initialize.
 	
 	name := SBLabel new
-		contents: 'variant X';
-		layoutInset: 5 @ 5;
-		hResizing: #spaceFill.
+		text: (SBOwnTextMorph new
+			emphasis: TextEmphasis italic;
+			small);
+		contents: 'Variant X'.
 	self widget: (SBTabView
 		namedBlocks: {SBNamedBlock block: (SBStBlockBody emptyWithDeclarations: {'a'. 'c'}) named: 'Code'}
 		activeIndex: 1).
@@ -206,7 +207,7 @@ SBVariant >> initialize [
 		cellGap: 2.0;
 		listDirection: #topToBottom;
 		changeTableLayout;
-		addAllMorphsBack: {name. widget};
+		addAllMorphsBack: {name . widget};
 		vResizing: #shrinkWrap;
 		hResizing: #shrinkWrap
 ]
@@ -225,6 +226,7 @@ SBVariant >> name [
 
 { #category : #accessing }
 SBVariant >> name: aString [
+
 	name contents: aString
 ]
 

--- a/packages/Sandblocks-Utils/SBPermutation.class.st
+++ b/packages/Sandblocks-Utils/SBPermutation.class.st
@@ -15,6 +15,7 @@ Class {
 SBPermutation class >> allPermutationsOf: aCollectionOfVariants [
 
 	| permutations |
+	aCollectionOfVariants ifEmpty:[^#()].
 	permutations := (1 to: aCollectionOfVariants first alternativesCount) collect: #asArray.
 	
 	(2 to: aCollectionOfVariants size) do: [:i | | alternatives |

--- a/packages/Sandblocks-Watch/SBAxisNotation.class.st
+++ b/packages/Sandblocks-Watch/SBAxisNotation.class.st
@@ -86,13 +86,20 @@ SBAxisNotation >> scale: aSBScale numberTicks: aNumber [
 SBAxisNotation >> visualize [
 
 	self submorphs copy do: #abandon.
-	self relativeTickHeights withIndexDo: [:aFraction :i | | annotation |
-		annotation := SBOwnTextMorph new 
-			contents: ((self scale scaledValueOfRelative: aFraction) asString);
-			layoutFrame: (LayoutFrame new topFraction: aFraction).
-		"Fraction 1 will result in the text being just underneath ourself, so substract height as offset"
-		(aFraction = 1) ifTrue: [annotation layoutFrame topOffset: (-1*(annotation minExtent y))].
-		self addMorph: annotation.]
+	
+	self addAllMorphsBack: (
+		self relativeTickHeights do: [:aFraction | | annotation |
+			annotation := SBOwnTextMorph new 
+				contents: ((self scale domainValueOfRelative: aFraction) asFloat asString);
+				verySmall;
+				layoutFrame: (LayoutFrame new topFraction: (1 - aFraction)).
+			
+			"Move text center to be fraction. 0 and 1 will be adjusted to align at the borders."
+			annotation layoutFrame topOffset: (-0.5*(annotation minExtent y)).
+			(aFraction = 1) ifTrue: [annotation layoutFrame topOffset: 0].
+			(aFraction = 0) ifTrue: [annotation layoutFrame topOffset: (-1*(annotation minExtent y))].
+			
+			^ annotation])
 		
 	
 ]

--- a/packages/Sandblocks-Watch/SBAxisNotation.class.st
+++ b/packages/Sandblocks-Watch/SBAxisNotation.class.st
@@ -1,0 +1,98 @@
+"
+A numerical legend for a scale
+"
+Class {
+	#name : #SBAxisNotation,
+	#superclass : #Morph,
+	#instVars : [
+		'scale',
+		'numberTicks'
+	],
+	#category : #'Sandblocks-Watch'
+}
+
+{ #category : #'initialize-release' }
+SBAxisNotation class >> newFromScale: aSBScale ticking: aNumber [
+
+	^ self new
+		scale: aSBScale
+		numberTicks: aNumber
+]
+
+{ #category : #initialization }
+SBAxisNotation >> initialize [ 
+
+	super initialize.
+	
+	numberTicks := 3.
+	scale := SBScale newLinearScaleWithDomain: (0 to: 100) forRange: (0 to: 100).
+	
+	self color: Color transparent;
+		layoutPolicy: ProportionalLayout new;
+		hResizing: #shrinkWrap;
+		vResizing: #spaceFill
+]
+
+{ #category : #accessing }
+SBAxisNotation >> numberTicks [
+
+	^ numberTicks
+]
+
+{ #category : #accessing }
+SBAxisNotation >> numberTicks: aNumber [
+
+	numberTicks := aNumber.
+	
+	self visualize
+]
+
+{ #category : #visualization }
+SBAxisNotation >> relativeTickHeights [
+
+	| section adjustedTicks |
+	(self numberTicks < 2) ifTrue: [^#()].
+	
+	"Starting count from 0 here instead of 1"
+	adjustedTicks := self numberTicks - 1.
+	section := 1 / adjustedTicks.
+	^ (0 to: adjustedTicks) collect: [:i | (section * i)]
+]
+
+{ #category : #accessing }
+SBAxisNotation >> scale [
+
+	^ scale
+]
+
+{ #category : #accessing }
+SBAxisNotation >> scale: aSBScale [
+
+	scale := aSBScale.
+	
+	self visualize
+]
+
+{ #category : #accessing }
+SBAxisNotation >> scale: aSBScale numberTicks: aNumber [
+
+	scale := aSBScale.
+	numberTicks := aNumber.
+	
+	self visualize
+]
+
+{ #category : #visualization }
+SBAxisNotation >> visualize [
+
+	self submorphs copy do: #abandon.
+	self relativeTickHeights withIndexDo: [:aFraction :i | | annotation |
+		annotation := SBOwnTextMorph new 
+			contents: ((self scale scaledValueOfRelative: aFraction) asString);
+			layoutFrame: (LayoutFrame new topFraction: aFraction).
+		"Fraction 1 will result in the text being just underneath ourself, so substract height as offset"
+		(aFraction = 1) ifTrue: [annotation layoutFrame topOffset: (-1*(annotation minExtent y))].
+		self addMorph: annotation.]
+		
+	
+]

--- a/packages/Sandblocks-Watch/SBAxisNotation.class.st
+++ b/packages/Sandblocks-Watch/SBAxisNotation.class.st
@@ -88,7 +88,7 @@ SBAxisNotation >> visualize [
 	self submorphs copy do: #abandon.
 	
 	self addAllMorphsBack: (
-		self relativeTickHeights do: [:aFraction | | annotation |
+		self relativeTickHeights collect: [:aFraction | | annotation |
 			annotation := SBOwnTextMorph new 
 				contents: ((self scale domainValueOfRelative: aFraction) asFloat asString);
 				verySmall;
@@ -99,7 +99,7 @@ SBAxisNotation >> visualize [
 			(aFraction = 1) ifTrue: [annotation layoutFrame topOffset: 0].
 			(aFraction = 0) ifTrue: [annotation layoutFrame topOffset: (-1*(annotation minExtent y))].
 			
-			^ annotation])
+			annotation])
 		
 	
 ]

--- a/packages/Sandblocks-Watch/SBBarChart.class.st
+++ b/packages/Sandblocks-Watch/SBBarChart.class.st
@@ -22,7 +22,7 @@ SBBarChart class >> newWithValues: traceValues [
 { #category : #'visualization - constants' }
 SBBarChart >> barWidth [
 
-	^ self spaceBetweenPoints / 3
+	^ self spaceBetweenPoints / 2
 ]
 
 { #category : #visualization }
@@ -36,11 +36,12 @@ SBBarChart >> newBarFor: aValue at: positionIndex [
 		color: Color transparent;
 		balloonText: aValue printString;
 		addMorph: (Morph new
-			color: (self datapointColorForValue: aValue);
+			color: self datapointDefaultColor;
 			width: self barWidth;
-			height: (self scaleY scaledValueOf: aValue);
-			bottom: self class canvasHeight + self class heightMargin ;
+			height: {(self scaleY scaledValueOf: aValue). 1} max;
+			bottom: self class canvasHeight + self class heightMargin;
 			left: positionIndex * self spaceBetweenPoints;
+			setProperty: #chartValue toValue: (self scaleY scaledValueOf: aValue);
 			yourself);
 		yourself
 	
@@ -55,13 +56,13 @@ SBBarChart >> newDataPoints [
 ]
 
 { #category : #visualization }
-SBBarChart >> visualizationMorph [
+SBBarChart >> newLineFrom: aDataPointMorph1 to: aDataPointMorph2 [
 	
-	| visualizationMorph |
-	visualizationMorph := self newBackground.
+	^ LineMorph 
+		from: aDataPointMorph1 topCenter 
+		to: aDataPointMorph2 topCenter  
+		color: ((self lineColorFrom: aDataPointMorph1 to: aDataPointMorph2) alpha: 0.2)
+		width: self lineWidth
 		
-	visualizationMorph addAllMorphs: self newDataPoints.
-	visualizationMorph addAllMorphsBack: (self newScaleLinesOn: visualizationMorph).
 	
-	^ visualizationMorph
 ]

--- a/packages/Sandblocks-Watch/SBBarChart.class.st
+++ b/packages/Sandblocks-Watch/SBBarChart.class.st
@@ -1,0 +1,67 @@
+Class {
+	#name : #SBBarChart,
+	#superclass : #SBLineChart,
+	#category : #'Sandblocks-Watch'
+}
+
+{ #category : #'initialize-release' }
+SBBarChart class >> newWithValues: traceValues [
+	
+	| valuesToVisualize |
+	valuesToVisualize := traceValues 
+		ifEmpty: [#(0)]
+		ifNotEmpty: [traceValues].
+	^ self new
+		traceValues: valuesToVisualize;
+		scaleY: (SBScale 
+			newLinearScaleWithDomain: (({valuesToVisualize min. 0} min) to: valuesToVisualize max) 
+			forRange: (0 to: self canvasHeight));
+		yourself
+]
+
+{ #category : #'visualization - constants' }
+SBBarChart >> barWidth [
+
+	^ self spaceBetweenPoints / 3
+]
+
+{ #category : #visualization }
+SBBarChart >> newBarFor: aValue at: positionIndex [
+	
+	"There is an extra Morph containing the datapoint itself so the tooltip is far easier to activate through more area"
+	^ Morph new
+		height: self class preferredHeight;
+		left: ((positionIndex - 0.5) * self spaceBetweenPoints) rounded;
+		width: self spaceBetweenPoints;
+		color: Color transparent;
+		balloonText: aValue printString;
+		addMorph: (Morph new
+			color: (self datapointColorForValue: aValue);
+			width: self barWidth;
+			height: (self scaleY scaledValueOf: aValue);
+			bottom: self class canvasHeight + self class heightMargin ;
+			left: positionIndex * self spaceBetweenPoints;
+			yourself);
+		yourself
+	
+		
+	
+]
+
+{ #category : #visualization }
+SBBarChart >> newDataPoints [
+	
+	^ self traceValues collectWithIndex: [:aTraceValue :index | self newBarFor: aTraceValue at: index]
+]
+
+{ #category : #visualization }
+SBBarChart >> visualizationMorph [
+	
+	| visualizationMorph |
+	visualizationMorph := self newBackground.
+		
+	visualizationMorph addAllMorphs: self newDataPoints.
+	visualizationMorph addAllMorphsBack: (self newScaleLinesOn: visualizationMorph).
+	
+	^ visualizationMorph
+]

--- a/packages/Sandblocks-Watch/SBLineChart.class.st
+++ b/packages/Sandblocks-Watch/SBLineChart.class.st
@@ -25,16 +25,6 @@ SBLineChart class >> supportedInterface [
 	^ #isNumber
 ]
 
-{ #category : #visualization }
-SBLineChart >> datapointColorForValue: aValue [
-	
-	| scaledValue |
-	scaledValue := self scaleY scaleBehavior value: self scaleY domain value: aValue.
-	(scaledValue <= self class highlightedDataPercentage) ifTrue: [^ self datapointLowerPercentColor].
-	(scaledValue >= (1 - self class highlightedDataPercentage)) ifTrue: [^ self datapointHigherPercentColor].
-	^ self datapointDefaultColor
-]
-
 { #category : #'visualization - constants' }
 SBLineChart >> datapointDefaultColor [
 	
@@ -47,30 +37,26 @@ SBLineChart >> datapointExtent [
 	^ 5@5
 ]
 
-{ #category : #'visualization - constants' }
-SBLineChart >> datapointHigherPercentColor [
-	
-	^ Color green
-]
-
-{ #category : #'visualization - constants' }
-SBLineChart >> datapointLowerPercentColor [
-	
-	^ Color red
-]
-
 { #category : #visualization }
-SBLineChart >> lineColorFrom: aPoint1 to: aPoint2 [
+SBLineChart >> lineColorFrom: aDataPoint1 to: aDataPoint2 [
 	
-	^ (aPoint1 y >= aPoint2 y) 
-		ifTrue: [self datapointHigherPercentColor]
-		ifFalse: [self datapointLowerPercentColor]
+	"Comparing y coordinates might yield false results as the coordinates are rounded
+	to whole numbers"
+	^ ((aDataPoint1 valueOfProperty: #chartValue) <= (aDataPoint2 valueOfProperty: #chartValue))
+		ifTrue: [self positiveGradientColor]
+		ifFalse: [self negativeGradientColor]
 ]
 
 { #category : #'visualization - constants' }
 SBLineChart >> lineWidth [
 	
 	^ 2
+]
+
+{ #category : #'visualization - constants' }
+SBLineChart >> negativeGradientColor [
+	
+	^ Color red
 ]
 
 { #category : #visualization }
@@ -92,10 +78,11 @@ SBLineChart >> newDatapointFor: aValue at: positionIndex [
 		balloonText: aValue printString;
 		addMorph: (EllipseMorph new
 			extent: self datapointExtent;
-			color: (self datapointColorForValue: aValue);
+			color: self datapointDefaultColor;
 			borderWidth: 0;
 			left: positionIndex * self spaceBetweenPoints;
 			top: self class canvasHeight - (self scaleY scaledValueOf: aValue);
+			setProperty: #chartValue toValue: (self scaleY scaledValueOf: aValue); 
 			yourself);
 		yourself
 	
@@ -109,7 +96,7 @@ SBLineChart >> newLineFrom: aDataPointMorph1 to: aDataPointMorph2 [
 	^ LineMorph 
 		from: aDataPointMorph1 center 
 		to: aDataPointMorph2 center 
-		color: (self lineColorFrom: aDataPointMorph1 center to: aDataPointMorph2 center)
+		color: (self lineColorFrom: aDataPointMorph1 to: aDataPointMorph2)
 		width: self lineWidth
 		
 	
@@ -125,16 +112,47 @@ SBLineChart >> newLinesForDatapointsOn: visualizationMorph [
 ]
 
 { #category : #visualization }
-SBLineChart >> newScaleLinesOn: aMorph [
+SBLineChart >> newScaleLineFrom: anOrigin to: anEnd [ 
 	
-	^ {LineMorph from: 0@self scaleYOffset to: aMorph width@self scaleYOffset
-		color: self scaleLineColor width: self scaleLineWidth.
-		LineMorph from: 0@(self class canvasHeight/2)+self scaleYOffset to: aMorph width@(self class canvasHeight/2)+self scaleYOffset
-		color: self scaleLineColor width: self scaleLineWidth.
-		LineMorph from: 0@self class canvasHeight + self scaleYOffset to: aMorph width@self class canvasHeight + self scaleYOffset
-		color: self scaleLineColor width: self scaleLineWidth.}
+	^ LineMorph from: anOrigin to: anEnd color: self scaleLineColor width: self scaleLineWidth
 		
 	
+]
+
+{ #category : #visualization }
+SBLineChart >> newScaleLineHeight: height length: length [ 
+	
+	^ LineMorph 
+		from: 0 @ height 
+		to: length @ height 
+		color: self scaleLineColor 
+		width: self scaleLineWidth
+		
+	
+]
+
+{ #category : #visualization }
+SBLineChart >> newScaleLinesOn: aMorph [
+	
+	| section |
+	section := self class canvasHeight / (self numberScaleLines - 1).
+	
+	^ (0 to: (self numberScaleLines - 1)) collect: [:i | 
+		self newScaleLineHeight: (section * i) + self scaleYOffset length: aMorph width]
+		
+	
+]
+
+{ #category : #'visualization - constants' }
+SBLineChart >> numberScaleLines [
+
+	^ 5
+]
+
+{ #category : #'visualization - constants' }
+SBLineChart >> positiveGradientColor [
+	
+	^ Color green
 ]
 
 { #category : #'visualization - constants' }

--- a/packages/Sandblocks-Watch/SBLineChart.class.st
+++ b/packages/Sandblocks-Watch/SBLineChart.class.st
@@ -1,0 +1,163 @@
+Class {
+	#name : #SBLineChart,
+	#superclass : #SBVisualization,
+	#category : #'Sandblocks-Watch'
+}
+
+{ #category : #'initialize-release' }
+SBLineChart class >> newWithValues: traceValues [
+	
+	| valuesToVisualize |
+	valuesToVisualize := traceValues 
+		ifEmpty: [#(0)]
+		ifNotEmpty: [traceValues].
+	^ self new
+		traceValues: valuesToVisualize;
+		scaleY: (SBScale 
+			newLinearScaleWithDomain: (valuesToVisualize min to: valuesToVisualize max) 
+			forRange: (0 to: self canvasHeight));
+		yourself
+]
+
+{ #category : #conversion }
+SBLineChart class >> supportedInterface [
+	
+	^ #isNumber
+]
+
+{ #category : #visualization }
+SBLineChart >> datapointColorForValue: aValue [
+	
+	| scaledValue |
+	scaledValue := self scaleY scaleBehavior value: self scaleY domain value: aValue.
+	(scaledValue <= self class highlightedDataPercentage) ifTrue: [^ self datapointLowerPercentColor].
+	(scaledValue >= (1 - self class highlightedDataPercentage)) ifTrue: [^ self datapointHigherPercentColor].
+	^ self datapointDefaultColor
+]
+
+{ #category : #'visualization - constants' }
+SBLineChart >> datapointDefaultColor [
+	
+	^ self sandblockForegroundColor
+]
+
+{ #category : #'visualization - constants' }
+SBLineChart >> datapointExtent [
+	
+	^ 5@5
+]
+
+{ #category : #'visualization - constants' }
+SBLineChart >> datapointHigherPercentColor [
+	
+	^ Color green
+]
+
+{ #category : #'visualization - constants' }
+SBLineChart >> datapointLowerPercentColor [
+	
+	^ Color red
+]
+
+{ #category : #visualization }
+SBLineChart >> lineColorFrom: aPoint1 to: aPoint2 [
+	
+	^ (aPoint1 y >= aPoint2 y) 
+		ifTrue: [self datapointHigherPercentColor]
+		ifFalse: [self datapointLowerPercentColor]
+]
+
+{ #category : #'visualization - constants' }
+SBLineChart >> lineWidth [
+	
+	^ 2
+]
+
+{ #category : #visualization }
+SBLineChart >> newDataPoints [
+	
+	^ self traceValues collectWithIndex: [:aTraceValue :index |
+		 self newDatapointFor: aTraceValue at: index]
+]
+
+{ #category : #visualization }
+SBLineChart >> newDatapointFor: aValue at: positionIndex [
+	
+	"There is an extra Morph containing the datapoint itself so the tooltip is far easier to activate through more area"
+	^ Morph new
+		height: self class preferredHeight;
+		left: ((positionIndex - 0.5) * self spaceBetweenPoints) rounded;
+		width: self spaceBetweenPoints;
+		color: Color transparent;
+		balloonText: aValue printString;
+		addMorph: (EllipseMorph new
+			extent: self datapointExtent;
+			color: (self datapointColorForValue: aValue);
+			borderWidth: 0;
+			left: positionIndex * self spaceBetweenPoints;
+			top: self class canvasHeight - (self scaleY scaledValueOf: aValue);
+			yourself);
+		yourself
+	
+		
+	
+]
+
+{ #category : #visualization }
+SBLineChart >> newLineFrom: aDataPointMorph1 to: aDataPointMorph2 [
+	
+	^ LineMorph 
+		from: aDataPointMorph1 center 
+		to: aDataPointMorph2 center 
+		color: (self lineColorFrom: aDataPointMorph1 center to: aDataPointMorph2 center)
+		width: self lineWidth
+		
+	
+]
+
+{ #category : #visualization }
+SBLineChart >> newLinesForDatapointsOn: visualizationMorph [
+	
+	^ visualizationMorph submorphs overlappingPairsCollect: [:oneDataPointMorph :anotherDataPointMorph | 
+		self 
+			newLineFrom: oneDataPointMorph firstSubmorph
+			to: anotherDataPointMorph firstSubmorph]
+]
+
+{ #category : #visualization }
+SBLineChart >> newScaleLinesOn: aMorph [
+	
+	^ {LineMorph from: 0@self scaleYOffset to: aMorph width@self scaleYOffset
+		color: self scaleLineColor width: self scaleLineWidth.
+		LineMorph from: 0@(self class canvasHeight/2)+self scaleYOffset to: aMorph width@(self class canvasHeight/2)+self scaleYOffset
+		color: self scaleLineColor width: self scaleLineWidth.
+		LineMorph from: 0@self class canvasHeight + self scaleYOffset to: aMorph width@self class canvasHeight + self scaleYOffset
+		color: self scaleLineColor width: self scaleLineWidth.}
+		
+	
+]
+
+{ #category : #'visualization - constants' }
+SBLineChart >> scaleYOffset [
+	
+	^ self datapointExtent y / 2
+]
+
+{ #category : #'visualization - constants' }
+SBLineChart >> spaceBetweenPoints [
+	
+	^ 15
+]
+
+{ #category : #visualization }
+SBLineChart >> visualizationMorph [
+	
+	| visualizationMorph |
+	visualizationMorph := self newBackground.
+		
+	visualizationMorph addAllMorphs: self newDataPoints.
+	visualizationMorph addAllMorphsBack: (self newLinesForDatapointsOn: visualizationMorph).
+	visualizationMorph addAllMorphsBack: (self newScaleLinesOn: visualizationMorph).
+	
+	^ visualizationMorph
+]

--- a/packages/Sandblocks-Watch/SBRectangleChart.class.st
+++ b/packages/Sandblocks-Watch/SBRectangleChart.class.st
@@ -1,0 +1,211 @@
+Class {
+	#name : #SBRectangleChart,
+	#superclass : #SBVisualization,
+	#instVars : [
+		'scaleX'
+	],
+	#category : #'Sandblocks-Watch'
+}
+
+{ #category : #constants }
+SBRectangleChart class >> coordinateSystemSize [
+	
+	^ self canvasHeight @ self canvasHeight
+]
+
+{ #category : #'initialize-release' }
+SBRectangleChart class >> newWithValues: traceValues [
+	
+	| biggestCoordinate absolutePoints |
+	absolutePoints := traceValues collect: [:aPoint | aPoint abs].
+	biggestCoordinate := {absolutePoints max x. absolutePoints max y} max.
+	^ self new
+		traceValues: traceValues;
+		scaleY: (SBScale 
+			newLinearScaleWithDomain:  (biggestCoordinate negated to: biggestCoordinate) 
+			forRange: (self coordinateSystemSize y / 2 negated to: self coordinateSystemSize y  / 2))
+		scaleX: (SBScale  
+			newLinearScaleWithDomain: (biggestCoordinate negated to: biggestCoordinate) 
+			forRange: (self coordinateSystemSize x / 2 negated to: self coordinateSystemSize x  / 2));
+		yourself
+]
+
+{ #category : #constants }
+SBRectangleChart class >> preferredHeight [
+	
+	^ 40
+]
+
+{ #category : #conversion }
+SBRectangleChart class >> supportedInterface [
+	
+	^ #isPoint
+]
+
+{ #category : #visualization }
+SBRectangleChart >> borderStyleFor: scaledValues [
+	
+	| borderWidth color |
+	borderWidth := 0.
+	color := Color transparent.
+	
+	((scaledValues y <= self class highlightedDataPercentage) 
+	or: [scaledValues x <= self class highlightedDataPercentage])
+		ifTrue: [ borderWidth := borderWidth + 1. color := self valueLowerPercentColor.].	
+			
+	((scaledValues y >= (1 - self class highlightedDataPercentage)) 
+	or: [scaledValues x >= (1 - self class highlightedDataPercentage)])
+		ifTrue: [ borderWidth := borderWidth + 1. color := self valueHigherPercentColor.].	
+			
+	(borderWidth >= 2) ifTrue: [color := self valueHigherLowerPercentColor].
+	
+	^  BorderStyle width: borderWidth color: color
+]
+
+{ #category : #visualization }
+SBRectangleChart >> newCoordinateSystemFor: aValue at: positionIndex [
+	
+	| left center |
+	"There is an extra Morph containing the lines so the tooltip is far easier to activate through more area"
+	left := ((positionIndex - 1) * self spaceBetweenPoints) rounded.
+	center := ((positionIndex - 0.5) * self spaceBetweenPoints) rounded.
+	^ Morph new
+		extent: self class coordinateSystemSize;
+		left: left;
+		width: self spaceBetweenPoints;
+		color: Color transparent;
+		balloonText: aValue printString;
+		addAllMorphs: 
+			{LineMorph 
+				from: center@0 
+				to: center@(self class coordinateSystemSize y)
+				color: self lineColor width: self scaleLineWidth.
+			LineMorph 
+				from: left@(self class coordinateSystemSize y / 2) 
+				to: (left + self spaceBetweenPoints)@(self class coordinateSystemSize y / 2) 
+				color: self lineColor width: self scaleLineWidth.};
+		yourself
+]
+
+{ #category : #visualization }
+SBRectangleChart >> newCoordinateSystems [
+	
+	^ self traceValues collectWithIndex: [:aTraceValue :index |
+		 self newCoordinateSystemFor: aTraceValue at: index]
+]
+
+{ #category : #visualization }
+SBRectangleChart >> newRectangleFor: aValue at: positionIndex [
+	
+	| scaledWidth scaledHeight left |
+	scaledWidth := self scaleX scaledValueOf: aValue x.
+	scaledHeight := self scaleY scaledValueOf: aValue y.
+	left := ((positionIndex - 0.5) * self spaceBetweenPoints) rounded.
+	
+	^ Morph new
+		extent: scaledWidth abs@scaledHeight abs;
+		color: (self rectangleColorForValue: aValue);
+		borderStyle: (self borderStyleFor: (scaledWidth @ scaledHeight));
+		left:  (scaledWidth / 2) + left;
+		top: (self class coordinateSystemSize y / 2) - (scaledHeight abs / 2) - (scaledHeight/2) ;
+		yourself
+	
+]
+
+{ #category : #visualization }
+SBRectangleChart >> newRectangles [
+	
+	^ self traceValues collectWithIndex: [:aTraceValue :index |
+		 self newRectangleFor: aTraceValue at: index]
+]
+
+{ #category : #visualization }
+SBRectangleChart >> rectangleColorForValue: aPoint [
+	
+	(aPoint x >= 0 and: [aPoint y >= 0]) ifTrue: [^ self rectanglePosPosColor].
+	(aPoint x >= 0 and: [aPoint y < 0]) ifTrue: [^ self rectanglePosNegColor].
+	(aPoint x < 0 and: [aPoint y < 0]) ifTrue: [^ self rectangleNegNegColor].
+	(aPoint x < 0 and: [aPoint y >= 0]) ifTrue: [^ self rectangleNegPosColor].
+]
+
+{ #category : #'visualization - constants' }
+SBRectangleChart >> rectangleNegNegColor [
+	
+	^ Color red
+]
+
+{ #category : #'visualization - constants' }
+SBRectangleChart >> rectangleNegPosColor [
+	
+	^ Color bubblegum
+]
+
+{ #category : #'visualization - constants' }
+SBRectangleChart >> rectanglePosNegColor [
+	
+	^ Color bubblegum
+]
+
+{ #category : #'visualization - constants' }
+SBRectangleChart >> rectanglePosPosColor [
+	
+	^ Color green
+]
+
+{ #category : #accessing }
+SBRectangleChart >> scaleX [
+
+	^ scaleX
+]
+
+{ #category : #accessing }
+SBRectangleChart >> scaleX: aSBScale [
+
+	scaleX := aSBScale.
+	
+	self visualize
+]
+
+{ #category : #accessing }
+SBRectangleChart >> scaleY: aYSBScale scaleX: aXSBScale [
+
+	scaleY := aYSBScale.
+	scaleX := aXSBScale.
+	
+	self visualize
+]
+
+{ #category : #'visualization - constants' }
+SBRectangleChart >> spaceBetweenPoints [
+	
+	^ self class coordinateSystemSize x
+]
+
+{ #category : #'visualization - constants' }
+SBRectangleChart >> valueHigherLowerPercentColor [
+	
+	^ Color black
+]
+
+{ #category : #'visualization - constants' }
+SBRectangleChart >> valueHigherPercentColor [
+	
+	^ Color green
+]
+
+{ #category : #'visualization - constants' }
+SBRectangleChart >> valueLowerPercentColor [
+	
+	^ Color red
+]
+
+{ #category : #visualization }
+SBRectangleChart >> visualizationMorph [
+	
+	| visualizationMorph |
+	visualizationMorph := self newBackground.
+	visualizationMorph addAllMorphs: self newCoordinateSystems.
+	visualizationMorph addAllMorphs: self newRectangles.
+	
+	^ visualizationMorph
+]

--- a/packages/Sandblocks-Watch/SBScale.class.st
+++ b/packages/Sandblocks-Watch/SBScale.class.st
@@ -1,0 +1,98 @@
+"
+A scale inspired by their usage in d3. Define a domain from which a set of numbers gets projected to your defined range. Both are Interval objects. As operations like min or array accesses don't work on reversed ordered Intervals (eg meaning they're sorted descendingly), only ascending intervals work.
+
+A scale behavior is a block accepting a domain and a value to scale. The output is a percentage [0;1] representing its relative position in your domain. It can scale the value linear, logarithmic, exponentially etc. For an example, view class > linearScale.
+"
+Class {
+	#name : #SBScale,
+	#superclass : #Object,
+	#instVars : [
+		'range',
+		'domain',
+		'scaleBehavior'
+	],
+	#category : #'Sandblocks-Watch'
+}
+
+{ #category : #scaleBehaviors }
+SBScale class >> linearScaleBehavior [
+	
+	^ [:domain :value | ((value - domain min) /  {domain extent. 1} max) abs]
+]
+
+{ #category : #'initialize-release' }
+SBScale class >> newLinearScaleWithDomain: aDomainInterval forRange: aRangeInterval [
+	
+	^ self new
+		domain: (
+			{aDomainInterval start. aDomainInterval stop} min 
+			to: {aDomainInterval start. aDomainInterval stop} max);
+		range: (
+			{aRangeInterval start. aRangeInterval stop} min 
+			to: {aRangeInterval start. aRangeInterval stop} max);
+		scaleBehavior: self linearScaleBehavior;
+		yourself
+]
+
+{ #category : #'initialize-release' }
+SBScale class >> newWithDomain: aDomainInterval forRange: aRangeInterval scalingLike: aScaleBehavior [
+	
+	^ self new
+		domain: aDomainInterval;
+		range: aRangeInterval;
+		scaleBehavior: aScaleBehavior;
+		yourself.
+]
+
+{ #category : #accessing }
+SBScale >> domain [
+
+	^ domain
+]
+
+{ #category : #accessing }
+SBScale >> domain: anInterval [
+
+	domain := anInterval
+]
+
+{ #category : #accessing }
+SBScale >> range [
+
+	^ range
+]
+
+{ #category : #accessing }
+SBScale >> range: anInterval [ 
+
+	range := anInterval
+]
+
+{ #category : #accessing }
+SBScale >> scaleBehavior [
+
+	^ scaleBehavior
+]
+
+{ #category : #accessing }
+SBScale >> scaleBehavior: aBlock [
+
+	scaleBehavior := aBlock
+]
+
+{ #category : #calculating }
+SBScale >> scaledValueOf: aNumberInDomain [
+	
+	"In case the given number is the start of the domain, meaning always at 0% of total range, 
+	we might get a ZeroDivide during calculations, so catch the case early by return."
+	(aNumberInDomain = self domain first) ifTrue: [^ self range first]. 
+	
+	^ self range at: (self scaleBehavior value: self domain value: aNumberInDomain) * self range extent +1
+]
+
+{ #category : #calculating }
+SBScale >> scaledValueOfRelative: aNumberFrom0To1 [
+	
+	"LERP the given number in domain before proceeding normally"
+	^ self scaledValueOf: ((1 - aNumberFrom0To1) * self domain min + aNumberFrom0To1 * self domain max)
+]

--- a/packages/Sandblocks-Watch/SBScale.class.st
+++ b/packages/Sandblocks-Watch/SBScale.class.st
@@ -56,6 +56,13 @@ SBScale >> domain: anInterval [
 	domain := anInterval
 ]
 
+{ #category : #calculating }
+SBScale >> domainValueOfRelative: aNumberFrom0To1 [
+	
+	"LERP the given number in domain before proceeding normally"
+	^ (1 - aNumberFrom0To1) * self domain min + (aNumberFrom0To1 * self domain max)
+]
+
 { #category : #accessing }
 SBScale >> range [
 
@@ -88,11 +95,4 @@ SBScale >> scaledValueOf: aNumberInDomain [
 	(aNumberInDomain = self domain first) ifTrue: [^ self range first]. 
 	
 	^ self range at: (self scaleBehavior value: self domain value: aNumberInDomain) * self range extent +1
-]
-
-{ #category : #calculating }
-SBScale >> scaledValueOfRelative: aNumberFrom0To1 [
-	
-	"LERP the given number in domain before proceeding normally"
-	^ self scaledValueOf: ((1 - aNumberFrom0To1) * self domain min + aNumberFrom0To1 * self domain max)
 ]

--- a/packages/Sandblocks-Watch/SBVisualization.class.st
+++ b/packages/Sandblocks-Watch/SBVisualization.class.st
@@ -52,7 +52,7 @@ SBVisualization class >> newWithValues: traceValues [
 { #category : #constants }
 SBVisualization class >> preferredHeight [
 	
-	^ 50 sbScaled 
+	^ 100 sbScaled 
 ]
 
 { #category : #conversion }
@@ -90,13 +90,15 @@ SBVisualization class >> visualizationObjectForValues: traceValues overMorph: tr
 { #category : #visualization }
 SBVisualization >> axisYNotation [
 	
-	^ SBAxisNotation newFromScale: self scaleY ticking: 3 
+	^ SBAxisNotation newFromScale: self scaleY ticking: 5 
 ]
 
 { #category : #initialization }
 SBVisualization >> initialize [ 
 
 	super initialize.
+	
+	self selectable: false.
 	
 	self color: self drawnColor;
 		layoutPolicy: TableLayout new;
@@ -134,7 +136,7 @@ SBVisualization >> newBackground [
 { #category : #'visualization - constants' }
 SBVisualization >> scaleLineColor [
 	
-	^ self sandblockForegroundColor
+	^ self sandblockForegroundColor alpha: 0.3
 ]
 
 { #category : #'visualization - constants' }

--- a/packages/Sandblocks-Watch/SBVisualization.class.st
+++ b/packages/Sandblocks-Watch/SBVisualization.class.st
@@ -1,0 +1,190 @@
+"
+A SBVisualization transforms the contents of watches to visual projections for easier reading. 
+
+traceValues are the values getting projected. 
+scaleY is a BPScale used to project your values to the canvas appropriately. The x direction is hardcoded; the morph can be
+as wide as it needs to be.
+
+Subclasses must provide following methods:
+instance-sided: 
+- visualizationMorph: The visualization itself provided as a Morph
+
+class-sided: 
+- newWithValues: forMorph: : Default constructor. Define a default scale here too.
+- supportedInterface: Which interface is supported to be visualized? We assume homogeneous collections for traceValues.
+
+Add a converter function to Collection, see #asLineChart for example
+"
+Class {
+	#name : #SBVisualization,
+	#superclass : #SBBlock,
+	#instVars : [
+		'scaleY',
+		'traceValues'
+	],
+	#category : #'Sandblocks-Watch'
+}
+
+{ #category : #constants }
+SBVisualization class >> canvasHeight [
+	
+	^ self preferredHeight - self heightMargin
+]
+
+{ #category : #constants }
+SBVisualization class >> heightMargin [
+	
+	^ 5 sbScaled
+]
+
+{ #category : #constants }
+SBVisualization class >> highlightedDataPercentage [
+	
+	^ 0.1
+]
+
+{ #category : #'initialize-release' }
+SBVisualization class >> newWithValues: traceValues [
+	
+	^ self subclassResponsibility
+]
+
+{ #category : #constants }
+SBVisualization class >> preferredHeight [
+	
+	^ 50 sbScaled 
+]
+
+{ #category : #conversion }
+SBVisualization class >> supportedInterface [
+	
+	^ self subclassResponsibility
+]
+
+{ #category : #constants }
+SBVisualization class >> traceValuesMorphClassesToFilterOut [
+	
+	^ {StringMorph}
+]
+
+{ #category : #conversion }
+SBVisualization class >> visualizationClassesForValues: traceValues [
+	
+	| containedClasses |
+	containedClasses := (traceValues collect: [:tracedValue | tracedValue class]) asSet.
+	^ self allSubclasses select: [:aSubclass |
+		containedClasses allSatisfy: [:aTracedValueClass | aTracedValueClass withAllSuperclasses includes: aSubclass supportedClass]]
+]
+
+{ #category : #'initialize-release' }
+SBVisualization class >> visualizationObjectForValues: traceValues overMorph: traceValuesMorph [
+	
+	| responsibleSubclasses |
+	responsibleSubclasses := self visualizationClassesForValues: traceValues.
+	(responsibleSubclasses isEmpty)
+		ifTrue: [^ (self newWithValues: traceValues forMorph: traceValuesMorph) visualizationMorph].
+		
+	^ (responsibleSubclasses first newWithValues: traceValues forMorph: traceValuesMorph)
+]
+
+{ #category : #visualization }
+SBVisualization >> axisYNotation [
+	
+	^ SBAxisNotation newFromScale: self scaleY ticking: 3 
+]
+
+{ #category : #initialization }
+SBVisualization >> initialize [ 
+
+	super initialize.
+	
+	self color: self drawnColor;
+		layoutPolicy: TableLayout new;
+		listDirection: #leftToRight;
+		hResizing: #shrinkWrap;
+		vResizing: #shrinkWrap;
+		borderWidth: 0;
+		yourself
+]
+
+{ #category : #testing }
+SBVisualization >> isTopLevel [
+
+	^ true
+]
+
+{ #category : #'visualization - constants' }
+SBVisualization >> lineColor [
+	
+	^ self drawnColor 
+]
+
+{ #category : #visualization }
+SBVisualization >> newBackground [
+	
+	
+	^ Morph new
+		color: self drawnColor;
+		width: (self traceValues size + 2 "to have some margin") * self spaceBetweenPoints;
+		height: self class preferredHeight;
+		borderWidth: 0;
+		yourself
+]
+
+{ #category : #'visualization - constants' }
+SBVisualization >> scaleLineColor [
+	
+	^ self sandblockForegroundColor
+]
+
+{ #category : #'visualization - constants' }
+SBVisualization >> scaleLineWidth [ 
+	
+	^ 1
+]
+
+{ #category : #accessing }
+SBVisualization >> scaleY [
+
+	^ scaleY
+]
+
+{ #category : #accessing }
+SBVisualization >> scaleY: aSBScale [
+
+	scaleY := aSBScale.
+	
+	self visualize
+]
+
+{ #category : #'visualization - constants' }
+SBVisualization >> spaceBetweenPoints [
+	
+	^ 10 sbScaled 
+]
+
+{ #category : #accessing }
+SBVisualization >> traceValues [
+
+	^ traceValues
+]
+
+{ #category : #accessing }
+SBVisualization >> traceValues: aCollection [
+
+	traceValues := aCollection
+]
+
+{ #category : #visualization }
+SBVisualization >> visualizationMorph [
+	
+	^ self subclassResponsibility
+]
+
+{ #category : #visualization }
+SBVisualization >> visualize [ 
+	
+	self submorphs copy do: #abandon.
+		
+	self addAllMorphsBack: {self axisYNotation. self visualizationMorph}
+]

--- a/packages/Sandblocks-Watch/SBWatchView.class.st
+++ b/packages/Sandblocks-Watch/SBWatchView.class.st
@@ -125,10 +125,24 @@ SBWatchView >> displayWatchValues [
 		ifFalse: [self maxWidth]).
 ]
 
+{ #category : #'event handling' }
+SBWatchView >> doubleClick: evt [
+
+	super doubleClick: evt.
+	self exploreValues
+]
+
 { #category : #'colors and color policies' }
 SBWatchView >> drawnColor [
 
 	^ Color white
+]
+
+{ #category : #accessing }
+SBWatchView >> exploreValues [
+	<action>
+
+	self object explore
 ]
 
 { #category : #accessing }
@@ -183,7 +197,7 @@ SBWatchView >> layoutCommands [
 { #category : #accessing }
 SBWatchView >> maxWidth [
 
-	^ 450
+	^ 300
 ]
 
 { #category : #accessing }
@@ -202,7 +216,9 @@ SBWatchView >> object [
 { #category : #'event handling' }
 SBWatchView >> placeholder [
 
-	^  Morph new color: Color transparent; extent: (0@0)
+	^  Morph new 
+		color: Color transparent; 
+		extent: (0@0)
 ]
 
 { #category : #printing }
@@ -330,5 +346,6 @@ SBWatchView >> watchValuesContainer [
 		changeTableLayout;
 		listDirection: #leftToRight;
 		layoutInset: 1;
-		borderWidth: 0
+		borderWidth: 0;
+		on: #doubleClick send: #exploreValues to: self
 ]

--- a/packages/Sandblocks-Watch/SBWatchView.class.st
+++ b/packages/Sandblocks-Watch/SBWatchView.class.st
@@ -51,7 +51,7 @@ SBWatchView >> changeDisplay [
 	index := UIManager default chooseFrom: (options collect: #first).
 	index = 0 ifTrue: [^ self].
 	
-	self useDisplay: (options at: index) second
+	self displayOnScrollPane: (options at: index) second.
 ]
 
 { #category : #'event handling' }
@@ -110,19 +110,27 @@ SBWatchView >> display [
 ]
 
 { #category : #display }
+SBWatchView >> displayOnScrollPane: aMorph [
+
+	self scroller removeAllMorphs.
+	
+	self scroller addMorph: aMorph.
+	self scrollPane height: aMorph height + self scrollBarHeight.
+	
+	"Simulates an expanding layout"
+	self scrollPane width: (aMorph width <= self maxWidth 
+		ifTrue: [aMorph width] 
+		ifFalse: [self maxWidth])
+]
+
+{ #category : #display }
 SBWatchView >> displayWatchValues [
 
 	| valuesMorph |
-	self scroller removeAllMorphs.
 	valuesMorph := self watchValuesContainer.
 	watchValues do: [:aValue | valuesMorph addMorphBack: (aValue asValueMorph)].
 
-	self scroller addMorph: valuesMorph.
-	self scrollPane height: valuesMorph height + self scrollBarHeight.
-	"Simulates an expanding layout"
-	self scrollPane width: (valuesMorph width <= self maxWidth 
-		ifTrue: [valuesMorph width] 
-		ifFalse: [self maxWidth]).
+	self displayOnScrollPane: valuesMorph.
 ]
 
 { #category : #'event handling' }
@@ -292,13 +300,6 @@ SBWatchView >> updateDisplay [
 			visible: true].
 		
 	self displayWatchValues
-]
-
-{ #category : #display }
-SBWatchView >> useDisplay: aDisplay [
-
-	self display delete.
-	self addMorph: aDisplay atIndex: 2. 
 ]
 
 { #category : #accessing }

--- a/packages/Sandblocks-Watch/SBWatchView.class.st
+++ b/packages/Sandblocks-Watch/SBWatchView.class.st
@@ -47,7 +47,8 @@ SBWatchView >> changeDisplay [
 	<action>
 
 	| index options |
-	options := Array streamContents: [:stream | self values allConversionsFor: SBInterfaces topLevel do: [:pair | stream nextPut: pair]].
+	options := Array streamContents: [:stream | self values allConversionsFor: SBInterfaces topLevel do: [:pair | stream nextPut: pair]]. 
+	options := options, {{'default'. self watchValuesContainer addAllMorphsBack: (watchValues collect: #asValueMorph)}}.
 	index := UIManager default chooseFrom: (options collect: #first).
 	index = 0 ifTrue: [^ self].
 	

--- a/packages/Sandblocks-Watch/SBWatchView.class.st
+++ b/packages/Sandblocks-Watch/SBWatchView.class.st
@@ -47,7 +47,8 @@ SBWatchView >> changeDisplay [
 	<action>
 
 	| index options |
-	options := Array streamContents: [:stream | self values allConversionsFor: SBInterfaces topLevel do: [:pair | stream nextPut: pair]]. 
+	options := Array streamContents: [:stream | 
+		self values allConversionsFor: SBInterfaces topLevel do: [:pair | stream nextPut: pair]]. 
 	options := options, {{'default'. self watchValuesContainer addAllMorphsBack: (watchValues collect: #asValueMorph)}}.
 	index := UIManager default chooseFrom: (options collect: #first).
 	index = 0 ifTrue: [^ self].


### PR DESCRIPTION
For quick overview of a collection of either numbers or points, users can now click on the visualization button next to an example's label in a watch. Currently implemented are line charts, bar charts, and rectangle charts, which all implement the abstract `SBVisualization` class. They replace the existing `SBGraphPlot` class which is now obsolete and deleted. 

For scaling behavior similiar to d3, a `SBScale` has been added. `SBAxisNotation` is responsible for displaying ticks. 

This MR is dependent on #124 which should be merged first.

![image](https://github.com/hpi-swa/sandblocks/assets/33000454/fab933d2-c008-4364-bd6d-7b4247e35aa3)
![image](https://github.com/hpi-swa/sandblocks/assets/33000454/f868b377-6dc2-4c46-a0e9-6136d10bb0b2)
![image](https://github.com/hpi-swa/sandblocks/assets/33000454/31bc031d-2c59-47c0-a85f-c38a97d90508)
![image](https://github.com/hpi-swa/sandblocks/assets/33000454/7a3b0dd2-7526-4abb-b17d-bfb4d02ce5fb)


