### PR TITLE
Adds support for variants in dynamic ui methods

### DIFF
--- a/packages/Sandblocks-Babylonian/SBExampleValueDisplay.class.st
+++ b/packages/Sandblocks-Babylonian/SBExampleValueDisplay.class.st
@@ -22,6 +22,12 @@ SBExampleValueDisplay >> clear [
 ]
 
 { #category : #accessing }
+SBExampleValueDisplay >> displayedWatchValueBlocks [
+
+	^ display displayedMorphs
+]
+
+{ #category : #accessing }
 SBExampleValueDisplay >> exampleFinished: anExample [
 
 	display exampleFinished: anExample.

--- a/packages/Sandblocks-Babylonian/SBExampleWatch.class.st
+++ b/packages/Sandblocks-Babylonian/SBExampleWatch.class.st
@@ -247,7 +247,7 @@ SBExampleWatch >> initialize [
 			prefix: 'Dimensions: ';
 			labels: (options collect: #label);
 			values: options;
-			object: options first;
+			object: options third;
 			when: #selectionChanged send: #applyResizerOnValues to: self.
 	modifyExpression := SBStBlockBody identityNamed: 'each'.
 	

--- a/packages/Sandblocks-Babylonian/SBExploriants.class.st
+++ b/packages/Sandblocks-Babylonian/SBExploriants.class.st
@@ -1,6 +1,12 @@
+"
+objectToPermutation is a WeakKeyDictionary to enable permutation execution for dynamic objects. E.G. UI is run in a shared process which does not know the SBActiveVariantPermutation of the example processes, resulting in all morphs running the same step method. 
+"
 Class {
 	#name : #SBExploriants,
 	#superclass : #SBTabView,
+	#instVars : [
+		'objectToPermutation'
+	],
 	#classInstVars : [
 		'uniqueInstance'
 	],
@@ -20,6 +26,12 @@ SBExploriants class >> new [
 ]
 
 { #category : #accessing }
+SBExploriants class >> objectToPermutation [
+
+	^ self uniqueInstance objectToPermutation
+]
+
+{ #category : #accessing }
 SBExploriants class >> uniqueInstance [ 
 
 	^ uniqueInstance ifNil: [uniqueInstance := super new]
@@ -36,6 +48,8 @@ SBExploriants >> initialize [
 
 	super initialize.
 	
+	objectToPermutation := WeakKeyDictionary new.
+	
 	self
 		attachDecorator: SBMoveDecorator new;
 		changeTableLayout;
@@ -47,6 +61,12 @@ SBExploriants >> initialize [
 SBExploriants >> isArtefact [ 
 
 	^ true
+]
+
+{ #category : #accessing }
+SBExploriants >> objectToPermutation [
+
+	^ objectToPermutation
 ]
 
 { #category : #'artefact protocol' }

--- a/packages/Sandblocks-Babylonian/SBInactiveExampleWatch.class.st
+++ b/packages/Sandblocks-Babylonian/SBInactiveExampleWatch.class.st
@@ -13,6 +13,7 @@ SBInactiveExampleWatch class >> newFromWatch: anActiveWatch [
 	^ (anActiveWatch veryDeepCopy)
 		primitiveChangeClassTo: self basicNew;
 		expression: (SBTextBubble new contents: anActiveWatch expression sourceString);
+		saveObjectsActivePermutations;
 		yourself 
 ]
 
@@ -21,7 +22,8 @@ SBInactiveExampleWatch >> artefactSaved: aBlock [
 
 	"As we are inactive, we have to manually apply our modifyExpression if it changes. 
 	Otherwise, we would reset by examples starting" 
-	(aBlock = self containingArtefact) ifTrue: [self applyModifyExpressionOnValues]
+	(aBlock = self containingArtefact) 
+		ifTrue: [self applyModifyExpressionOnValues. self saveObjectsActivePermutations.]
 ]
 
 { #category : #'event handling' }
@@ -47,4 +49,15 @@ SBInactiveExampleWatch >> isActive [
 SBInactiveExampleWatch >> listensToExamples [
 
 	^ false
+]
+
+{ #category : #'*Sandblocks-Babylonian' }
+SBInactiveExampleWatch >> saveObjectsActivePermutations [
+
+	"Force morphs to persist their permutation even when on the UI process"
+	exampleToDisplay associationsDo: [:anExampleDisplayPair |
+		anExampleDisplayPair value displayedWatchValueBlocks do: [:aValueMorph | 
+			SBExploriants objectToPermutation 
+				at: aValueMorph lastSubmorph 
+				put: SBActiveVariantPermutation value]].
 ]

--- a/packages/Sandblocks-Babylonian/SBInactiveExampleWatch.extension.st
+++ b/packages/Sandblocks-Babylonian/SBInactiveExampleWatch.extension.st
@@ -5,3 +5,14 @@ SBInactiveExampleWatch >> listensToExamples [
 
 	^ false
 ]
+
+{ #category : #'*Sandblocks-Babylonian' }
+SBInactiveExampleWatch >> saveObjectsActivePermutations [
+
+	"Force morphs to persist their permutation even when on the UI process"
+	exampleToDisplay associationsDo: [:anExampleDisplayPair |
+		anExampleDisplayPair value displayedWatchValueBlocks do: [:aValueMorph | 
+			SBExploriants objectToPermutation 
+				at: aValueMorph lastSubmorph 
+				put: SBActiveVariantPermutation value]].
+]

--- a/packages/Sandblocks-Smalltalk/SBVariant.class.st
+++ b/packages/Sandblocks-Smalltalk/SBVariant.class.st
@@ -66,11 +66,21 @@ SBVariant class >> named: aString alternatives: aCollectionOfNamedBlocks activeI
 { #category : #'instance creation' }
 SBVariant class >> named: aString associations: aCollectionOfAssociations activeIndex: aNumber id: uuid [
 
+	| defaultBehavior requestor requiredPermutation |
 	aNumber <= 0 ifTrue: [^ nil].
-	^ SBActiveVariantPermutation value 
-		ifNil: [(aCollectionOfAssociations at: aNumber) value value]
-		ifNotNil: [(aCollectionOfAssociations at: (SBActiveVariantPermutation value at: uuid)) value value].
-		
+	"Always prioritize the permutation which is marked as active"
+	SBActiveVariantPermutation value ifNotNil: [^ (aCollectionOfAssociations at: (SBActiveVariantPermutation value at: uuid)) value value].
+	
+	defaultBehavior := (aCollectionOfAssociations at: aNumber) value value.
+	
+	"The requesting object does not require dynamic update behavior in which it needs to know a certain alternative"
+	SBExploriants objectToPermutation at: (requestor := thisContext sender receiver) ifAbsent: [^ defaultBehavior].
+	"The permutation is outdated and does not know this variant"
+	(requiredPermutation := SBExploriants objectToPermutation at: requestor) at: uuid ifAbsent: [^ defaultBehavior].
+	"An outdated permutation in which an alternative with a higher index than current has been deleted"
+	aCollectionOfAssociations at: (requiredPermutation at: uuid) ifAbsent: [^ defaultBehavior].
+	
+	^ (aCollectionOfAssociations at: (requiredPermutation at: uuid)) value value
 ]
 
 { #category : #'instance creation' }

--- a/packages/Sandblocks-Watch/SBMorphResizer.class.st
+++ b/packages/Sandblocks-Watch/SBMorphResizer.class.st
@@ -53,7 +53,7 @@ SBMorphResizer class >> newThumbmail [
 { #category : #'initialize-release' }
 SBMorphResizer class >> newTiny [
 
-	^ self newLabeled: 'small' transforming: [:aMorph | aMorph extent: 15@15]
+	^ self newLabeled: 'tiny' transforming: [:aMorph | aMorph extent: 15@15]
 ]
 
 { #category : #'initialize-release' }

--- a/packages/Sandblocks-Watch/SBWatchView.class.st
+++ b/packages/Sandblocks-Watch/SBWatchView.class.st
@@ -138,6 +138,12 @@ SBWatchView >> displayWatchValues [
 	self displayOnScrollPane: valuesMorph.
 ]
 
+{ #category : #accessing }
+SBWatchView >> displayedMorphs [
+
+	^ self scroller submorphs first "container for scrolling" submorphs 
+]
+
 { #category : #'event handling' }
 SBWatchView >> doubleClick: evt [
 


### PR DESCRIPTION
Previously, watched objects were static. The variants were only selected differently once when creating Exploriants. However, for methods such as step, this results in the same behavior for every permutation. This MR saves permutations in Exploriants and asks them when a variant is dissolved
![image](https://github.com/hpi-swa/sandblocks/assets/33000454/bfc87eea-bd93-4bdb-968c-6e5400b7556c)
