### PR TITLE
Consistent Resizing in Watches

### DIFF
--- a/packages/Sandblocks-Babylonian/SBExampleValueDisplay.class.st
+++ b/packages/Sandblocks-Babylonian/SBExampleValueDisplay.class.st
@@ -21,6 +21,12 @@ SBExampleValueDisplay >> clear [
 	hadValue := false
 ]
 
+{ #category : #'as yet unclassified' }
+SBExampleValueDisplay >> display [
+
+	^ display
+]
+
 { #category : #accessing }
 SBExampleValueDisplay >> displayedWatchValueBlocks [
 
@@ -125,6 +131,12 @@ SBExampleValueDisplay >> reportValues: aCollectionOfObjects name: aString sized:
 	label contents: aString.
 	label visible: aString notEmpty.
 	hadValue := true
+]
+
+{ #category : #actions }
+SBExampleValueDisplay >> resizeThrough: aMorphResizer [
+
+	display resizeThrough: aMorphResizer
 ]
 
 { #category : #actions }

--- a/packages/Sandblocks-Babylonian/SBExampleValueDisplay.class.st
+++ b/packages/Sandblocks-Babylonian/SBExampleValueDisplay.class.st
@@ -21,7 +21,7 @@ SBExampleValueDisplay >> clear [
 	hadValue := false
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBExampleValueDisplay >> display [
 
 	^ display

--- a/packages/Sandblocks-Babylonian/SBExampleWatch.class.st
+++ b/packages/Sandblocks-Babylonian/SBExampleWatch.class.st
@@ -116,8 +116,8 @@ SBExampleWatch >> applyModifyExpressionOnValues [
 { #category : #'event handling' }
 SBExampleWatch >> applyResizerOnValues [
 	
-	"Clearing everything here as Morphs get distorted when resized multiple times."
-	self applyModifyExpressionOnValues.
+	exampleToDisplay associationsDo: [:anExampleDisplayPair | 
+		anExampleDisplayPair value resizeThrough: self selectedMorphResizer]
 	
 ]
 
@@ -171,11 +171,12 @@ SBExampleWatch >> exampleStarting: anExample [
 
 	exampleToValues at: anExample put: OrderedCollection new.
 
-	(exampleToDisplay at: anExample ifAbsentPut: [ | display |
-		display := SBExampleValueDisplay new.
-		self addMorph: (exampleToDisplay at: anExample put: display) atIndex: 2.
+	(exampleToDisplay at: anExample ifAbsentPut: [ | valueDisplay |
+		valueDisplay := SBExampleValueDisplay new.
+		valueDisplay display fallbackResizer: self selectedMorphResizer.
+		self addMorph: (exampleToDisplay at: anExample put: valueDisplay) atIndex: 2.
 		anExample when: #outOfWorld send: #exampleStopped: to: self with: anExample.
-		display])
+		valueDisplay])
 		exampleStarting: anExample;
 		name: anExample label
 ]

--- a/packages/Sandblocks-Watch/SBBarChart.class.st
+++ b/packages/Sandblocks-Watch/SBBarChart.class.st
@@ -5,17 +5,18 @@ Class {
 }
 
 { #category : #'initialize-release' }
-SBBarChart class >> newWithValues: traceValues [
+SBBarChart class >> newWithValues: traceValues havingHeight: aNumber [
 	
 	| valuesToVisualize |
 	valuesToVisualize := traceValues 
 		ifEmpty: [#(0)]
 		ifNotEmpty: [traceValues].
 	^ self new
+		targetHeight: aNumber;
 		traceValues: valuesToVisualize;
 		scaleY: (SBScale 
 			newLinearScaleWithDomain: (({valuesToVisualize min. 0} min) to: valuesToVisualize max) 
-			forRange: (0 to: self canvasHeight));
+			forRange: (0 to: aNumber));
 		yourself
 ]
 
@@ -30,7 +31,7 @@ SBBarChart >> newBarFor: aValue at: positionIndex [
 	
 	"There is an extra Morph containing the datapoint itself so the tooltip is far easier to activate through more area"
 	^ Morph new
-		height: self class preferredHeight;
+		height: self targetHeight;
 		left: ((positionIndex - 0.5) * self spaceBetweenPoints) rounded;
 		width: self spaceBetweenPoints;
 		color: Color transparent;
@@ -39,7 +40,7 @@ SBBarChart >> newBarFor: aValue at: positionIndex [
 			color: self datapointDefaultColor;
 			width: self barWidth;
 			height: {(self scaleY scaledValueOf: aValue). 1} max;
-			bottom: self class canvasHeight + self class heightMargin;
+			bottom: self canvasHeight + self class heightMargin;
 			left: positionIndex * self spaceBetweenPoints;
 			setProperty: #chartValue toValue: (self scaleY scaledValueOf: aValue);
 			yourself);

--- a/packages/Sandblocks-Watch/SBLineChart.class.st
+++ b/packages/Sandblocks-Watch/SBLineChart.class.st
@@ -5,17 +5,18 @@ Class {
 }
 
 { #category : #'initialize-release' }
-SBLineChart class >> newWithValues: traceValues [
+SBLineChart class >> newWithValues: traceValues havingHeight: aNumber [
 	
 	| valuesToVisualize |
 	valuesToVisualize := traceValues 
 		ifEmpty: [#(0)]
 		ifNotEmpty: [traceValues].
 	^ self new
+		targetHeight: aNumber;
 		traceValues: valuesToVisualize;
 		scaleY: (SBScale 
 			newLinearScaleWithDomain: (valuesToVisualize min to: valuesToVisualize max) 
-			forRange: (0 to: self canvasHeight));
+			forRange: (0 to: aNumber));
 		yourself
 ]
 
@@ -71,7 +72,7 @@ SBLineChart >> newDatapointFor: aValue at: positionIndex [
 	
 	"There is an extra Morph containing the datapoint itself so the tooltip is far easier to activate through more area"
 	^ Morph new
-		height: self class preferredHeight;
+		height: self targetHeight;
 		left: ((positionIndex - 0.5) * self spaceBetweenPoints) rounded;
 		width: self spaceBetweenPoints;
 		color: Color transparent;
@@ -81,7 +82,7 @@ SBLineChart >> newDatapointFor: aValue at: positionIndex [
 			color: self datapointDefaultColor;
 			borderWidth: 0;
 			left: positionIndex * self spaceBetweenPoints;
-			top: self class canvasHeight - (self scaleY scaledValueOf: aValue);
+			top: self canvasHeight - (self scaleY scaledValueOf: aValue);
 			setProperty: #chartValue toValue: (self scaleY scaledValueOf: aValue); 
 			yourself);
 		yourself
@@ -135,7 +136,7 @@ SBLineChart >> newScaleLineHeight: height length: length [
 SBLineChart >> newScaleLinesOn: aMorph [
 	
 	| section |
-	section := self class canvasHeight / (self numberScaleLines - 1).
+	section := self canvasHeight / (self numberScaleLines - 1).
 	
 	^ (0 to: (self numberScaleLines - 1)) collect: [:i | 
 		self newScaleLineHeight: (section * i) + self scaleYOffset length: aMorph width]

--- a/packages/Sandblocks-Watch/SBRectangleChart.class.st
+++ b/packages/Sandblocks-Watch/SBRectangleChart.class.st
@@ -7,33 +7,23 @@ Class {
 	#category : #'Sandblocks-Watch'
 }
 
-{ #category : #constants }
-SBRectangleChart class >> coordinateSystemSize [
-	
-	^ self canvasHeight @ self canvasHeight
-]
-
 { #category : #'initialize-release' }
-SBRectangleChart class >> newWithValues: traceValues [
+SBRectangleChart class >> newWithValues: traceValues havingHeight: aNumber [
 	
-	| biggestCoordinate absolutePoints |
+	| biggestCoordinate absolutePoints coordinateSystemSize |
 	absolutePoints := traceValues collect: [:aPoint | aPoint abs].
 	biggestCoordinate := {absolutePoints max x. absolutePoints max y} max.
+	coordinateSystemSize := aNumber - self heightMargin.
 	^ self new
+		targetHeight: aNumber;
 		traceValues: traceValues;
 		scaleY: (SBScale 
 			newLinearScaleWithDomain:  (biggestCoordinate negated to: biggestCoordinate) 
-			forRange: (self coordinateSystemSize y / 2 negated to: self coordinateSystemSize y  / 2))
+			forRange: (coordinateSystemSize / 2 negated to: coordinateSystemSize  / 2))
 		scaleX: (SBScale  
 			newLinearScaleWithDomain: (biggestCoordinate negated to: biggestCoordinate) 
-			forRange: (self coordinateSystemSize x / 2 negated to: self coordinateSystemSize x  / 2));
+			forRange: (coordinateSystemSize / 2 negated to: coordinateSystemSize  / 2));
 		yourself
-]
-
-{ #category : #constants }
-SBRectangleChart class >> preferredHeight [
-	
-	^ 40
 ]
 
 { #category : #conversion }
@@ -62,6 +52,12 @@ SBRectangleChart >> borderStyleFor: scaledValues [
 	^  BorderStyle width: borderWidth color: color
 ]
 
+{ #category : #'visualization - constants' }
+SBRectangleChart >> coordinateSystemSize [
+	
+	^ self canvasHeight @ self canvasHeight
+]
+
 { #category : #visualization }
 SBRectangleChart >> newCoordinateSystemFor: aValue at: positionIndex [
 	
@@ -70,7 +66,7 @@ SBRectangleChart >> newCoordinateSystemFor: aValue at: positionIndex [
 	left := ((positionIndex - 1) * self spaceBetweenPoints) rounded.
 	center := ((positionIndex - 0.5) * self spaceBetweenPoints) rounded.
 	^ Morph new
-		extent: self class coordinateSystemSize;
+		extent: self coordinateSystemSize;
 		left: left;
 		width: self spaceBetweenPoints;
 		color: Color transparent;
@@ -78,11 +74,11 @@ SBRectangleChart >> newCoordinateSystemFor: aValue at: positionIndex [
 		addAllMorphs: 
 			{LineMorph 
 				from: center@0 
-				to: center@(self class coordinateSystemSize y)
+				to: center@(self coordinateSystemSize y)
 				color: self lineColor width: self scaleLineWidth.
 			LineMorph 
-				from: left@(self class coordinateSystemSize y / 2) 
-				to: (left + self spaceBetweenPoints)@(self class coordinateSystemSize y / 2) 
+				from: left@(self coordinateSystemSize y / 2) 
+				to: (left + self spaceBetweenPoints)@(self coordinateSystemSize y / 2) 
 				color: self lineColor width: self scaleLineWidth.};
 		yourself
 ]
@@ -107,7 +103,7 @@ SBRectangleChart >> newRectangleFor: aValue at: positionIndex [
 		color: (self rectangleColorForValue: aValue);
 		borderStyle: (self borderStyleFor: (scaledWidth @ scaledHeight));
 		left:  (scaledWidth / 2) + left;
-		top: (self class coordinateSystemSize y / 2) - (scaledHeight abs / 2) - (scaledHeight/2) ;
+		top: (self coordinateSystemSize y / 2) - (scaledHeight abs / 2) - (scaledHeight/2) ;
 		yourself
 	
 ]
@@ -178,7 +174,7 @@ SBRectangleChart >> scaleY: aYSBScale scaleX: aXSBScale [
 { #category : #'visualization - constants' }
 SBRectangleChart >> spaceBetweenPoints [
 	
-	^ self class coordinateSystemSize x
+	^ self coordinateSystemSize x
 ]
 
 { #category : #'visualization - constants' }

--- a/packages/Sandblocks-Watch/SBVisualization.class.st
+++ b/packages/Sandblocks-Watch/SBVisualization.class.st
@@ -20,21 +20,22 @@ Class {
 	#superclass : #SBBlock,
 	#instVars : [
 		'scaleY',
-		'traceValues'
+		'traceValues',
+		'targetHeight'
 	],
 	#category : #'Sandblocks-Watch'
 }
 
 { #category : #constants }
-SBVisualization class >> canvasHeight [
+SBVisualization class >> defaultHeight [
 	
-	^ self preferredHeight - self heightMargin
+	^ 100 sbScaled 
 ]
 
 { #category : #constants }
-SBVisualization class >> heightMargin [
-	
-	^ 5 sbScaled
+SBVisualization class >> heightMargin [ 
+
+	^ 5 sbScaled 
 ]
 
 { #category : #constants }
@@ -46,13 +47,13 @@ SBVisualization class >> highlightedDataPercentage [
 { #category : #'initialize-release' }
 SBVisualization class >> newWithValues: traceValues [
 	
-	^ self subclassResponsibility
+	^ self newWithValues: traceValues havingHeight: self defaultHeight
 ]
 
-{ #category : #constants }
-SBVisualization class >> preferredHeight [
+{ #category : #'initialize-release' }
+SBVisualization class >> newWithValues: traceValues havingHeight: aNumber [
 	
-	^ 100 sbScaled 
+	^ self subclassResponsibility
 ]
 
 { #category : #conversion }
@@ -93,6 +94,21 @@ SBVisualization >> axisYNotation [
 	^ SBAxisNotation newFromScale: self scaleY ticking: 5 
 ]
 
+{ #category : #'visualization - constants' }
+SBVisualization >> canvasHeight [
+	
+	^ self targetHeight - self class heightMargin
+]
+
+{ #category : #geometry }
+SBVisualization >> extent: aPoint [
+
+	super extent: aPoint.
+	self targetHeight: aPoint y.
+	self scaleY range: (0 to: aPoint y).
+	self visualize
+]
+
 { #category : #initialization }
 SBVisualization >> initialize [ 
 
@@ -118,17 +134,16 @@ SBVisualization >> isTopLevel [
 { #category : #'visualization - constants' }
 SBVisualization >> lineColor [
 	
-	^ self drawnColor 
+	^ self foregroundColor 
 ]
 
 { #category : #visualization }
 SBVisualization >> newBackground [
-	
-	
+
 	^ Morph new
 		color: self drawnColor;
 		width: (self traceValues size + 2 "to have some margin") * self spaceBetweenPoints;
-		height: self class preferredHeight;
+		height: self targetHeight;
 		borderWidth: 0;
 		yourself
 ]
@@ -163,6 +178,18 @@ SBVisualization >> scaleY: aSBScale [
 SBVisualization >> spaceBetweenPoints [
 	
 	^ 10 sbScaled 
+]
+
+{ #category : #accessing }
+SBVisualization >> targetHeight [
+
+	^ targetHeight ifNil: [targetHeight:= self class defaultHeight]
+]
+
+{ #category : #accessing }
+SBVisualization >> targetHeight: aNumber [
+
+	targetHeight := aNumber
 ]
 
 { #category : #accessing }

--- a/packages/Sandblocks-Watch/SBWatchView.class.st
+++ b/packages/Sandblocks-Watch/SBWatchView.class.st
@@ -10,8 +10,8 @@ Class {
 		'dark',
 		'count',
 		'clear',
-		'updateScheduled',
-		'env'
+		'fallbackResizer',
+		'updateScheduled'
 	],
 	#category : #'Sandblocks-Watch'
 }
@@ -52,6 +52,7 @@ SBWatchView >> changeDisplay [
 	| index options |
 	options := Array streamContents: [:stream | 
 		self values allConversionsFor: SBInterfaces topLevel do: [:pair | stream nextPut: pair]]. 
+	options := options do: [:aPair | aPair at: 2 put: (self watchValuesContainer addMorphBack: (self fallbackResizer applyOn: aPair second))].
 	options := options, {{'default'. self watchValuesContainer addAllMorphsBack: (watchValues collect: #asValueMorph)}}.
 	index := UIManager default chooseFrom: (options collect: #first).
 	index = 0 ifTrue: [^ self].
@@ -165,6 +166,18 @@ SBWatchView >> exploreValues [
 ]
 
 { #category : #accessing }
+SBWatchView >> fallbackResizer [
+
+	^ fallbackResizer
+]
+
+{ #category : #accessing }
+SBWatchView >> fallbackResizer: aSBMorphResizer [
+
+	fallbackResizer := aSBMorphResizer
+]
+
+{ #category : #accessing }
 SBWatchView >> incrementCount [
 
 	count contents: (count contents + 1) asString
@@ -179,6 +192,7 @@ SBWatchView >> initialize [
 	updateScheduled := false.
 	numSavedValues := 1.
 	watchValues := LinkedList new.
+	fallbackResizer := SBMorphResizer newSmall.
 	
 	self
 		layoutPolicy: SBAlgebraLayout new;
@@ -247,21 +261,36 @@ SBWatchView >> printOn: aStream [
 	self object printOn: aStream
 ]
 
-{ #category : #accessing }
+{ #category : #actions }
 SBWatchView >> reportValue: anObject [
 
 	self reportValue: {anObject} sized: SBMorphResizer newIdentity
 ]
 
-{ #category : #accessing }
+{ #category : #actions }
 SBWatchView >> reportValues: aCollectionOfObjects sized: aMorphResizer [
 
+	self fallbackResizer: aMorphResizer.
 	aCollectionOfObjects do: [:anObject | self addValue: anObject sized: aMorphResizer].
 	self count: self count contents + aCollectionOfObjects size.
 	
 	updateScheduled ifFalse: [
 		updateScheduled := true.
 		Project current addDeferredUIMessage: [self updateDisplay]]
+]
+
+{ #category : #actions }
+SBWatchView >> resizeThrough: aMorphResizer [
+
+	"Clearing everything here as Morphs get distorted when resized multiple times."
+	| valuesMorph |
+	valuesMorph := self watchValuesContainer.
+	valuesMorph addAllMorphsBack: (self displayedMorphs 
+		collect: #sbSnapshot 
+		thenDo: [:aMorph | aMorphResizer applyOn: aMorph]).
+
+	self displayOnScrollPane: valuesMorph.
+	self fallbackResizer: aMorphResizer.
 ]
 
 { #category : #layout }


### PR DESCRIPTION
Instead of creating watch values on a resize, `SBWatchView` is responsible for resizing now. That way, different displays can be resized too. 
Refactors `SBVisualization` to be flexible in size

![image](https://github.com/hpi-swa/sandblocks/assets/33000454/6022b415-e690-481d-bbf7-e754e8af6589)
