### PR TITLE
Basic diffing between alternatives in `SBTabView`s

### DIFF
--- a/packages/Sandblocks-Babylonian/SBExploriants.class.st
+++ b/packages/Sandblocks-Babylonian/SBExploriants.class.st
@@ -43,6 +43,13 @@ SBExploriants >> = other [
 	^ self class = other class
 ]
 
+{ #category : #ui }
+SBExploriants >> buildTabs [
+
+	super buildTabs.
+	(self submorphNamed: #tabs) firstSubmorph delete.
+]
+
 { #category : #initialization }
 SBExploriants >> initialize [
 
@@ -80,6 +87,12 @@ SBExploriants >> selector [
 	" if this node represents any selector, return it here "
 
 	^ nil
+]
+
+{ #category : #accessing }
+SBExploriants >> tabs [
+
+	^ (self submorphNamed: #tabs) submorphs allButLast
 ]
 
 { #category : #actions }

--- a/packages/Sandblocks-Core/SBTabView.class.st
+++ b/packages/Sandblocks-Core/SBTabView.class.st
@@ -3,7 +3,8 @@ Class {
 	#superclass : #SBBlock,
 	#instVars : [
 		'namedBlocks',
-		'activeIndex'
+		'activeIndex',
+		'isShowingDiff'
 	],
 	#category : #'Sandblocks-Core'
 }
@@ -113,14 +114,14 @@ SBTabView >> addButton [
 
 	^ SBButton new
 		icon: (SBIcon iconPlus
-				size: 6.0 sbScaled;
-				color: (Color r: 0.0 g: 1 b: 0.0))
-			label: ''
+				size: 8.0 sbScaled;
+				color: (Color green))
 			do: [self addTab];
 		makeSmall;
 		cornerStyle: #squared;
+		balloonText: 'Add';
 		cellGap: -1.0 sbScaled;
-		layoutInset: (4.0 @ 4.0) sbScaled
+		layoutInset: (4.0 @ 5.0) sbScaled
 ]
 
 { #category : #commands }
@@ -139,6 +140,13 @@ SBTabView >> addTab [
 	<action>
 
 	self add: (self active veryDeepCopy name: self activeName, '_i')
+]
+
+{ #category : #callbacks }
+SBTabView >> artefactSaved: aMethodBlock [
+
+	(aMethodBlock = self containingArtefact and: [self isShowingDiff]) 
+		ifTrue: [self updateSelectedTab]
 ]
 
 { #category : #ui }
@@ -167,6 +175,20 @@ SBTabView >> blockAt: anIndex [
 	^ self namedBlocks at: anIndex
 ]
 
+{ #category : #diffing }
+SBTabView >> buildDiffBlockFrom: aNamedBlock to: anotherNamedBlock given: aDiffText [
+
+	(aNamedBlock == anotherNamedBlock) ifTrue: [^ aNamedBlock block vResizing: #spaceFill].
+	
+	^ SBTextBubble multiLine 
+		vResizing: #spaceFill;
+		contents: aDiffText, 
+			 (Text fromString: 
+				'', Character cr,
+				'==========', Character cr,
+				(aNamedBlock name)) 
+]
+
 { #category : #ui }
 SBTabView >> buildTabs [
 
@@ -174,6 +196,7 @@ SBTabView >> buildTabs [
 		addAllMorphsBack: (self namedBlocks collect: [:block | self asTabButton: block]);
 		name: #tabs;
 		addMorphBack: self addButton;
+		addMorphFront: self diffButton;
 		changeTableLayout;
 		listDirection: #leftToRight;
 		hResizing: #shrinkWrap)
@@ -182,7 +205,10 @@ SBTabView >> buildTabs [
 { #category : #ui }
 SBTabView >> buildView [
 
-	self addMorphBack: (self activeBlock hResizing: #spaceFill)
+	self addMorphBack:  ((self isShowingDiff 
+		ifTrue: [self diffForSelected]
+		ifFalse: [self activeBlock])
+			hResizing: #spaceFill)
 ]
 
 { #category : #ui }
@@ -202,6 +228,36 @@ SBTabView >> deleteButtonFor: aNamedBlock [
 	^ delete
 ]
 
+{ #category : #ui }
+SBTabView >> diffButton [
+
+	^ SBButton new
+		icon: (SBIcon iconCodeFork size: 12.0 sbScaled)
+			do: [self toggleDiffView];
+		makeSmall;
+		balloonText: 'Toggle diff to others';
+		cornerStyle: #squared;
+		cellGap: -1.0 sbScaled;
+		layoutInset: (4.0 @ 3.0) sbScaled
+]
+
+{ #category : #diffing }
+SBTabView >> diffForSelected [
+
+	| diffs |
+	diffs := self paddedDiffTexts.
+
+	"Some blocks are only able to print themselves with a block as parent (eg block bodies). 
+	Thats why we don't use a SBRow here"
+	^ SBBlock new
+		changeTableLayout;
+		listDirection: #leftToRight;
+		vResizing: #shrinkWrap;
+		hResizing: #shrinkWrap;
+		addAllMorphsBack: (self namedBlocks withIndexCollect: [:aNamedBlock :i | 
+			self buildDiffBlockFrom: aNamedBlock to: self active given: (diffs at: i)])
+]
+
 { #category : #initialization }
 SBTabView >> initialize [
 
@@ -209,12 +265,25 @@ SBTabView >> initialize [
 	
 	namedBlocks := {SBNamedBlock new} asOrderedCollection.
 	activeIndex := 1.
+	isShowingDiff := false.
 	
 	self
 		changeTableLayout;
 		listDirection: #topToBottom;
 		hResizing: #spaceFill;
 		vResizing: #shrinkWrap.
+]
+
+{ #category : #accessing }
+SBTabView >> isShowingDiff [
+
+	^ isShowingDiff
+]
+
+{ #category : #accessing }
+SBTabView >> isShowingDiff: aBoolean [ 
+
+	isShowingDiff := aBoolean
 ]
 
 { #category : #'shortcut-utility' }
@@ -333,6 +402,34 @@ SBTabView >> namedBlocks: aCollectionOfSBNamedBlocks activeIndex: aNumber [
 	self rebuild
 ]
 
+{ #category : #diffing }
+SBTabView >> paddedDiffTexts [
+
+	| diffs maxLines |
+	diffs := self namedBlocks collect: [:aNamedBlock |  
+		(TextDiffBuilder 
+				from: (self plainSourceStringFor: aNamedBlock) 
+				to: (self plainSourceStringFor: self active)) buildDisplayPatch].
+			
+	maxLines := (diffs collect: [:aText | aText lineCount]) max.
+	
+	^ diffs collect: [:aText | | paddedText |
+		paddedText := aText. 
+		(maxLines - aText lineCount) timesRepeat: [paddedText := paddedText, ('', Character cr)]. 
+		paddedText]
+]
+
+{ #category : #diffing }
+SBTabView >> plainSourceStringFor: aNamedBlock [
+
+	^ aNamedBlock block isBlockBody
+		ifFalse: [aNamedBlock block sourceString]
+		ifTrue: [ ((aNamedBlock block statements 
+				reject: #isUnknown) 
+				collect: #unwrappedSourceString)
+				fold: [:a :b | a, Character cr, b]]
+]
+
 { #category : #ui }
 SBTabView >> rebuild [
 
@@ -412,7 +509,15 @@ SBTabView >> tabCount [
 { #category : #accessing }
 SBTabView >> tabs [
 
-	^ (self submorphNamed: #tabs) submorphs
+	^ (self submorphNamed: #tabs) submorphs viewAllButFirstAndLast
+]
+
+{ #category : #actions }
+SBTabView >> toggleDiffView [
+
+	self isShowingDiff: self isShowingDiff not.
+	self view delete.
+	self buildView.
 ]
 
 { #category : #ui }

--- a/packages/Sandblocks-Core/SBTabView.class.st
+++ b/packages/Sandblocks-Core/SBTabView.class.st
@@ -408,8 +408,8 @@ SBTabView >> paddedDiffTexts [
 	| diffs maxLines |
 	diffs := self namedBlocks collect: [:aNamedBlock |  
 		(TextDiffBuilder 
-				from: (self plainSourceStringFor: aNamedBlock) 
-				to: (self plainSourceStringFor: self active)) buildDisplayPatch].
+				from: (self sourceStringFor: aNamedBlock) 
+				to: (self sourceStringFor: self active)) buildDisplayPatch].
 			
 	maxLines := (diffs collect: [:aText | aText lineCount]) max.
 	
@@ -417,17 +417,6 @@ SBTabView >> paddedDiffTexts [
 		paddedText := aText. 
 		(maxLines - aText lineCount) timesRepeat: [paddedText := paddedText, ('', Character cr)]. 
 		paddedText]
-]
-
-{ #category : #diffing }
-SBTabView >> plainSourceStringFor: aNamedBlock [
-
-	^ aNamedBlock block isBlockBody
-		ifFalse: [aNamedBlock block sourceString]
-		ifTrue: [ ((aNamedBlock block statements 
-				reject: #isUnknown) 
-				collect: #unwrappedSourceString)
-				fold: [:a :b | a, Character cr, b]]
 ]
 
 { #category : #ui }
@@ -477,6 +466,15 @@ SBTabView >> setActive: aNamedBlock [
 
 	self sandblockEditor do: 
 		(self switchCommandFor: (self namedBlocks indexOf: aNamedBlock ifAbsent: 1))
+]
+
+{ #category : #diffing }
+SBTabView >> sourceStringFor: aNamedBlock [
+
+	^ aNamedBlock block isBlockBody
+		ifFalse: [aNamedBlock block sourceString]
+		ifTrue: [ (aNamedBlock block statements collect: #sourceString)
+				fold: [:a :b | a, Character cr, b]]
 ]
 
 { #category : #commands }

--- a/packages/Sandblocks-Smalltalk/SBStMessageSend.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStMessageSend.class.st
@@ -553,15 +553,6 @@ SBStMessageSend >> tryReplacements [
 		option automatic ifTrue: [option apply: c]]
 ]
 
-{ #category : #converting }
-SBStMessageSend >> unwrappedSourceString [
-
-	^ String streamContents: [:aStream | 
-		self actualReceiver writeSourceOn: aStream.
-		aStream space.
-		signature writeSourceOn: aStream.]
-]
-
 { #category : #accessing }
 SBStMessageSend >> useAsVariable [
 	<action>

--- a/packages/Sandblocks-Smalltalk/SBStMessageSend.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStMessageSend.class.st
@@ -553,6 +553,15 @@ SBStMessageSend >> tryReplacements [
 		option automatic ifTrue: [option apply: c]]
 ]
 
+{ #category : #converting }
+SBStMessageSend >> unwrappedSourceString [
+
+	^ String streamContents: [:aStream | 
+		self actualReceiver writeSourceOn: aStream.
+		aStream space.
+		signature writeSourceOn: aStream.]
+]
+
 { #category : #accessing }
 SBStMessageSend >> useAsVariable [
 	<action>

--- a/packages/Sandblocks-Smalltalk/SBVariant.class.st
+++ b/packages/Sandblocks-Smalltalk/SBVariant.class.st
@@ -168,14 +168,6 @@ SBVariant >> blockAt: anIndex [
 ]
 
 { #category : #accessing }
-SBVariant >> codeFor: aNamedBlock [
-
-	^ (aNamedBlock block submorphs size > 1) 
-				ifTrue: [aNamedBlock block lastSubmorph]
-				ifFalse: [nil]
-]
-
-{ #category : #accessing }
 SBVariant >> color [
 
 	^ Color transparent
@@ -268,11 +260,11 @@ SBVariant >> replaceSelfWithBlock: aNamedBlock [
 	self widget: (SBTabView namedBlocks: {aNamedBlock} activeIndex: 1).
 	self addMorphBack: widget.
 	
-	command := (self codeFor: widget active)
-		ifNil: [SBDeleteCommand new target: self]
-		ifNotNil: [SBUnwrapConsecutiveCommand new 
+	command := (self statementsFor: widget active)
+		ifEmpty: [SBDeleteCommand new target: self]
+		ifNotEmpty: [:statements | SBUnwrapConsecutiveCommand new 
 									target: self; 
-									unwrapped: {(self codeFor: widget active)}].	
+									unwrapped: statements].
 	
 	self sandblockEditor do: command
 ]
@@ -282,11 +274,11 @@ SBVariant >> replaceSelfWithChosen [
 	
 	<action>
 	| command |
-	command := (self codeFor: widget active)
-		ifNil: [SBDeleteCommand new target: self]
-		ifNotNil: [SBUnwrapConsecutiveCommand new 
+	command := (self statementsFor: widget active)
+		ifEmpty: [SBDeleteCommand new target: self]
+		ifNotEmpty: [:statements | SBUnwrapConsecutiveCommand new 
 									target: self; 
-									unwrapped: {(self codeFor: widget active)}].	
+									unwrapped: statements].
 	
 	self sandblockEditor do: command
 ]
@@ -295,6 +287,14 @@ SBVariant >> replaceSelfWithChosen [
 SBVariant >> replaceValuesFrom: anotherVariant [
 
 	self named: anotherVariant name alternatives: anotherVariant alternatives activeIndex: anotherVariant activeIndex  
+]
+
+{ #category : #accessing }
+SBVariant >> statementsFor: aNamedBlock [
+
+	^ aNamedBlock block isBlockBody 
+		ifTrue: [aNamedBlock block statements]
+		ifFalse: [{}]
 ]
 
 { #category : #actions }
@@ -337,12 +337,8 @@ SBVariant >> writeSourceOn: aStream [
 	self alternatives
 		do: [:aNamedBlock |
 			aNamedBlock name storeOn: aStream.
-			aStream nextPutAll: ' -> ['.
-			(self codeFor: aNamedBlock)  
-				ifNotNil: [(self codeFor: aNamedBlock) writeSourceOn: aStream]
-				ifNil: [aStream nextPutAll: ' '].
-			aStream nextPut: $].
-			]
+			aStream nextPutAll: ' -> '.
+			aNamedBlock block writeSourceOn: aStream]
 		separatedBy: [aStream nextPut: $.].
 	aStream nextPutAll: '} activeIndex: '.
 	self activeIndex storeOn: aStream.


### PR DESCRIPTION
Adds a diffing button to tab views. On click, they reveal basic text diffs from the system's `TextDiffBuilder` from one tab to the others. Makes comparisons quicker.
Also fixes a fault in which only the last statement of an alternative was looked at in saving, replacing, etc.. The failure occured as soon as multiple lines are added.

![image](https://github.com/hpi-swa/sandblocks/assets/33000454/552fd87c-30e9-4205-9334-19484e5904e9)

![image](https://github.com/hpi-swa/sandblocks/assets/33000454/ff9cb564-24aa-40b9-a08f-e1ea9478aeda)
