### PR TITLE
Ignore un-nested permutations which are not possible

### DIFF
--- a/packages/Sandblocks-Core/SBBlock.class.st
+++ b/packages/Sandblocks-Core/SBBlock.class.st
@@ -2229,6 +2229,18 @@ SBBlock >> parentHasDynamicNumberOfChildren [
 	^ self parentSandblock fixedNumberOfChildren not
 ]
 
+{ #category : #accessing }
+SBBlock >> parentVariant [
+
+	^ self parentSandblock 
+		ifNil: [nil]
+		ifNotNil: [:theParent | 
+			theParent isVariant
+				ifTrue: [theParent] 
+				ifFalse: [theParent parentVariant]]
+
+]
+
 { #category : #actions }
 SBBlock >> pasteAfter [
 	<action>

--- a/packages/Sandblocks-Smalltalk/SBVariant.class.st
+++ b/packages/Sandblocks-Smalltalk/SBVariant.class.st
@@ -156,6 +156,29 @@ SBVariant >> alternativesEqual: otherAlternatives [
 ]
 
 { #category : #converting }
+SBVariant >> asNestedPaths [
+
+	| allPaths |
+	allPaths := OrderedCollection new.
+	self asNestedPaths: allPaths currentPath: (SBPermutation new referencedVariants: OrderedCollection new). 
+	^ allPaths
+]
+
+{ #category : #converting }
+SBVariant >> asNestedPaths: allPaths currentPath: aPermutation [
+
+	"Private helper function"
+ 	self namedBlocks withIndexCollect: [:aNamedBlock :i | | nestedVariants currentPath |
+		nestedVariants := aNamedBlock block childSandblocks select: #isVariant. 
+		currentPath := aPermutation copyWith: (self id -> i).
+		currentPath referencedVariants: (aPermutation referencedVariants copyWith: self).
+		nestedVariants 
+			ifEmpty: [allPaths add: currentPath]
+			ifNotEmpty: [:children | children do: [:child | 
+					child asNestedPaths: allPaths currentPath: currentPath]]]
+]
+
+{ #category : #converting }
 SBVariant >> asProxy [
 
 	^ SBVariantProxy for: self

--- a/packages/Sandblocks-Utils/SBPermutation.class.st
+++ b/packages/Sandblocks-Utils/SBPermutation.class.st
@@ -14,21 +14,30 @@ Class {
 { #category : #utils }
 SBPermutation class >> allPermutationsOf: aCollectionOfVariants [
 
-	| permutations |
+	| permutations topLevelVariants nestedPermutations |
 	aCollectionOfVariants ifEmpty:[^{SBNilPermutation new referencedVariants: {}}].
-	permutations := (1 to: aCollectionOfVariants first alternativesCount) collect: #asArray.
+	topLevelVariants := aCollectionOfVariants select: [:aVariant | aVariant parentVariant isNil].
+	nestedPermutations := topLevelVariants collect: #asNestedPaths.
+	permutations := nestedPermutations first.
 	
-	(2 to: aCollectionOfVariants size) do: [:i | | alternatives |
-		alternatives := (aCollectionOfVariants at: i) alternativesCount.
-		permutations := permutations gather: [:aCollectionOfIndexes | 
-			(1 to: alternatives) collect: [:aTabIndex | 
-				{aCollectionOfIndexes. aTabIndex} flatten]]].
+	(2 to: topLevelVariants size) do: [:i | | nestedPermutation |
+		nestedPermutation := (nestedPermutations at: i).
+		permutations := permutations gather: [:aPermutation | 
+			nestedPermutation collect: [:aNestedPermutation | self newCombinedOf: aPermutation and: aNestedPermutation]]].
 	
-	^ permutations collect: [:aCollectionOfIndexes | 
-		(self withAll: (aCollectionOfIndexes withIndexCollect: [:anAlternativeIndex :aVariantIndex | 
-			(aCollectionOfVariants at: aVariantIndex) id -> anAlternativeIndex]))
-		referencedVariants: aCollectionOfVariants]
+	^ permutations 
 		
+]
+
+{ #category : #utils }
+SBPermutation class >> newCombinedOf: onePermutation and: anotherPermutation [
+
+	| result |
+	result := self new referencedVariants: (onePermutation referencedVariants, anotherPermutation referencedVariants).
+	result addAll: onePermutation.
+	result addAll: anotherPermutation.
+	^ result
+	
 ]
 
 { #category : #actions }


### PR DESCRIPTION
Given a nested variant like this
![image](https://github.com/hpi-swa/sandblocks/assets/33000454/a57dd765-b43c-4ad7-bb41-c92bdff5abe4)
![image](https://github.com/hpi-swa/sandblocks/assets/33000454/01c7328c-de16-49b4-ba9f-9bdd052f062a)

The permutations red>original and red>alternative will never occur, as the variant is nested inside green. This MR changes the simple permutation calculation of crossing everything with each other to a dfs crossing of top level variants. 