### PR TITLE
Usage (+technical) Improvements Part 2

### DIFF
--- a/packages/Sandblocks-Babylonian/Morph.extension.st
+++ b/packages/Sandblocks-Babylonian/Morph.extension.st
@@ -7,7 +7,7 @@ Morph class >> exampleObject [
 ]
 
 { #category : #'*Sandblocks-Babylonian' }
-Morph >> listensToPermutations [
+Morph >> listensToPermutations [ 
 
 	^ false
 ]

--- a/packages/Sandblocks-Babylonian/Morph.extension.st
+++ b/packages/Sandblocks-Babylonian/Morph.extension.st
@@ -7,6 +7,12 @@ Morph class >> exampleObject [
 ]
 
 { #category : #'*Sandblocks-Babylonian' }
+Morph >> listensToPermutations [
+
+	^ false
+]
+
+{ #category : #'*Sandblocks-Babylonian' }
 Morph >> sbWatchValueMorphFor: aSBWatchValue sized: aSBMorphResizer [
 
 	^ (SBWatchValue newContainerMorphFor: aSBWatchValue)  

--- a/packages/Sandblocks-Babylonian/SBCluster.class.st
+++ b/packages/Sandblocks-Babylonian/SBCluster.class.st
@@ -11,9 +11,9 @@ Class {
 SBCluster >> compressedMorphsForDisplay: aSBWatchView [
 
 	| displayedMorphs |
-	displayedMorphs := aSBWatchView displayedMorphs collect: [:aMorph | 
-			aMorph watchValue morphResizer: self morphResizer. 
-			aMorph watchValue asValueMorph].
+	displayedMorphs := aSBWatchView watchValues collect: [:aWatchValue | 
+			aWatchValue morphResizer: self morphResizer. 
+			aWatchValue asValueMorph].
 	^ (displayedMorphs size = 1) 
 		ifTrue: [displayedMorphs first]
 		ifFalse: [self newCellMorph 

--- a/packages/Sandblocks-Babylonian/SBEditor.extension.st
+++ b/packages/Sandblocks-Babylonian/SBEditor.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : #SBEditor }
+
+{ #category : #'*Sandblocks-Babylonian' }
+SBEditor >> sendNewPermutationNotification [
+	
+	self allMorphsDo: [:morph | morph listensToPermutations ifTrue: [morph updateStyling]]
+	
+	 
+]

--- a/packages/Sandblocks-Babylonian/SBExample.class.st
+++ b/packages/Sandblocks-Babylonian/SBExample.class.st
@@ -423,7 +423,6 @@ SBExample >> runSynchronouslyIgnoreReturn [
 
 	| returned |
 	self sendStartNotification.
-	
 	SBExecutionEnvironment value: self.
 	[returned := self evaluate] on: Error do: [:e | self scheduleLastError: e].
 	self scheduleLastError: nil.

--- a/packages/Sandblocks-Babylonian/SBExample.class.st
+++ b/packages/Sandblocks-Babylonian/SBExample.class.st
@@ -419,15 +419,15 @@ SBExample >> runSetup [
 ]
 
 { #category : #'as yet unclassified' }
-SBExample >> runSynchronouslyIgnoreReturn [
+SBExample >> runSynchUpdatingOnlyValuesOf: aCollectionOfSBWatches [
 
 	| returned |
-	self sendStartNotification.
+	aCollectionOfSBWatches do: [:aWatch | aWatch resetOnlyValuesFor: self].
 	SBExecutionEnvironment value: self.
 	[returned := self evaluate] on: Error do: [:e | self scheduleLastError: e].
 	self scheduleLastError: nil.
+	aCollectionOfSBWatches do: [:aWatch | aWatch exampleFinished: self]
 	
-	self sendFinishNotification.
 ]
 
 { #category : #'as yet unclassified' }

--- a/packages/Sandblocks-Babylonian/SBExample.class.st
+++ b/packages/Sandblocks-Babylonian/SBExample.class.st
@@ -66,7 +66,7 @@ SBExample class >> newFor: aMessage [
 { #category : #'as yet unclassified' }
 SBExample class >> registerShortcuts: aProvider [
 
-	aProvider registerShortcut: $q command do: #wrapWithExampleWatch
+	aProvider registerShortcut: $w command do: #wrapWithExampleWatch
 ]
 
 { #category : #'as yet unclassified' }

--- a/packages/Sandblocks-Babylonian/SBExampleCluster.class.st
+++ b/packages/Sandblocks-Babylonian/SBExampleCluster.class.st
@@ -72,7 +72,7 @@ SBExampleCluster >> extractedTopHeadingsFrom: aSBMultiverse [
 	^ (aSBMultiverse universes collect: [:aUniverse | 
 		self newContainerMorph 
 			addAllMorphsBack: {
-				SBStringMorph new contents: aUniverse activePermutation asString.
+				TextMorph new contents: aUniverse activePermutation asStylizedText.
 				SBButton newApplyPermutationFor: aUniverse activePermutation}])
 ]
 

--- a/packages/Sandblocks-Babylonian/SBExampleCluster.class.st
+++ b/packages/Sandblocks-Babylonian/SBExampleCluster.class.st
@@ -71,9 +71,10 @@ SBExampleCluster >> extractedTopHeadingsFrom: aSBMultiverse [
 
 	^ (aSBMultiverse universes collect: [:aUniverse | 
 		self newContainerMorph 
+			listDirection: #leftToRight;
 			addAllMorphsBack: {
-				SBPermutationLabel newDisplaying: aUniverse activePermutation.
-				SBButton newApplyPermutationFor: aUniverse activePermutation}])
+				SBButton newApplyPermutationFor: aUniverse activePermutation.
+				SBPermutationLabel newDisplaying: aUniverse activePermutation}])
 ]
 
 { #category : #accessing }

--- a/packages/Sandblocks-Babylonian/SBExampleCluster.class.st
+++ b/packages/Sandblocks-Babylonian/SBExampleCluster.class.st
@@ -72,7 +72,7 @@ SBExampleCluster >> extractedTopHeadingsFrom: aSBMultiverse [
 	^ (aSBMultiverse universes collect: [:aUniverse | 
 		self newContainerMorph 
 			addAllMorphsBack: {
-				TextMorph new contents: aUniverse activePermutation asStylizedText.
+				SBPermutationLabel newDisplaying: aUniverse activePermutation.
 				SBButton newApplyPermutationFor: aUniverse activePermutation}])
 ]
 

--- a/packages/Sandblocks-Babylonian/SBExampleWatch.class.st
+++ b/packages/Sandblocks-Babylonian/SBExampleWatch.class.st
@@ -124,7 +124,21 @@ SBExampleWatch >> applyResizerOnValues [
 { #category : #copying }
 SBExampleWatch >> asInactiveCopy [
 
-	^ SBInactiveExampleWatch newFromWatch: self
+	"Ignore the existing morphs in ourselves and recreate the graphics from the data"
+	| copy |
+	copy := SBInactiveExampleWatch new 
+				newIdentifier;
+				expression: (SBTextBubble new contents: self cleanedExpression sourceString);
+				modifyExpression: self modifyExpression veryDeepCopy;
+				dimensionOptions: self dimensionOptions veryDeepCopy. 
+				
+	exampleToValues keys do: [:anExample |	copy exampleStarting: anExample;
+													   reportValues: (self valuesForExample: anExample) for: anExample;
+													   exampleFinished: anExample ].
+												
+	^ copy 
+		saveObjectsActivePermutations;
+		yourself
 ]
 
 { #category : #accessing }
@@ -160,6 +174,19 @@ SBExampleWatch >> color [
 SBExampleWatch >> deleteCommandFor: aBlock [
 
 	^ nil
+]
+
+{ #category : #accessing }
+SBExampleWatch >> dimensionOptions [ 
+
+	^ dimensionOptions
+]
+
+{ #category : #accessing }
+SBExampleWatch >> dimensionOptions: aSBComboBox [
+
+	"private"
+	dimensionOptions := aSBComboBox
 ]
 
 { #category : #'event handling' }
@@ -276,8 +303,8 @@ SBExampleWatch >> initialize [
 	super initialize.
 	options := SBMorphResizer standardOptions.
 	
-	exampleToDisplay := Dictionary new.
-	exampleToValues := Dictionary new.
+	exampleToDisplay := IdentityDictionary new.
+	exampleToValues := IdentityDictionary new.
 	watchedExpression := SBStMessageSend new.
 	dimensionOptions := SBComboBox new
 			prefix: 'Morph Dimensions: ';
@@ -425,6 +452,33 @@ SBExampleWatch >> reportValue: anObject for: anExample [
 		ifPresent: [:values | values add: anObject]
 ]
 
+{ #category : #actions }
+SBExampleWatch >> reportValues: aCollectionOfObjects for: anExample [ 
+
+	exampleToValues
+		at: anExample
+		ifPresent: [:values | values addAll: aCollectionOfObjects]
+]
+
+{ #category : #'event handling' }
+SBExampleWatch >> resetOnlyValuesFor: anExample [
+
+	"Private"
+	exampleToValues at: anExample put: OrderedCollection new.
+	(exampleToDisplay at: anExample) display resetOnlyValues
+	
+
+	
+]
+
+{ #category : #testing }
+SBExampleWatch >> resumeGraphicalUpdates [
+
+	exampleToDisplay values do: [:anExampleValueDisplay |
+		anExampleValueDisplay display shouldUpdateDisplay: true]
+
+]
+
 { #category : #accessing }
 SBExampleWatch >> selectedMorphResizer [
 
@@ -435,6 +489,14 @@ SBExampleWatch >> selectedMorphResizer [
 SBExampleWatch >> setWatchedExpressionUneditable [
 
 	watchedExpression selectable: false
+]
+
+{ #category : #testing }
+SBExampleWatch >> stopGraphicalUpdates [
+
+	exampleToDisplay values do: [:anExampleValueDisplay |
+		anExampleValueDisplay display shouldUpdateDisplay: false]
+
 ]
 
 { #category : #accessing }

--- a/packages/Sandblocks-Babylonian/SBExploriants.class.st
+++ b/packages/Sandblocks-Babylonian/SBExploriants.class.st
@@ -114,6 +114,34 @@ SBExploriants >> objectToPermutation [
 	^ objectToPermutation
 ]
 
+{ #category : #'as yet unclassified' }
+SBExploriants >> onlySwitchedTabsIn: aMethodBlock multiverse: aMultiverse [
+
+	| methodClass methodSelector latestChange diff changes |
+	(aMultiverse allMethodBlocksContainingVariants includes: aMethodBlock) 
+		ifFalse: [^ false].
+		
+	methodClass := aMethodBlock compiledMethod methodClass.
+	methodSelector := aMethodBlock compiledMethod selector.
+	latestChange := (ChangeSet 
+		scanVersionsOf: aMethodBlock compiledMethod
+		class: methodClass 
+		meta: methodClass isMeta
+		category: (methodClass organization categoryOfElement: methodSelector)
+		selector: methodSelector) second.
+	diff := TextDiffBuilder new
+		from: aMethodBlock compiledMethod getSource
+		to: latestChange text.
+	changes := OrderedCollection new.
+	diff patchSequenceDoIfMatch: [ :string |]
+			ifInsert: [ :string | changes add: string]
+			ifRemove: [ :string| changes add: string].
+	^ (changes allSatisfy: [:aString | aString matchesRegex: '\s*activeIndex\: \d*\s*']).
+		
+	
+	 
+]
+
 { #category : #'artefact protocol' }
 SBExploriants >> saveTryFixing: aFixBoolean quick: aQuickBoolean [
 
@@ -132,25 +160,19 @@ SBExploriants >> tryToUpdateInBackgroundAfterChangeIn: aMethodBlock [
 
 	| multiverse |
 	multiverse := self active multiverse.
-	"(multiverse allMethodBlocksContainingVariants includes: aMethodBlock) 
-		ifTrue: [ 
-			| methodClass methodSelector latestChange |
-			methodClass := aMethodBlock compiledMethod methodClass.
-			methodSelector := aMethodBlock compiledMethod selector.
-			self halt.
-			latestChange := (ChangeSet 
-				scanVersionsOf: aMethodBlock compiledMethod
-				class: methodClass 
-				meta: methodClass isMeta
-				category: (methodClass organization categoryOfElement: methodSelector)
-				selector: methodSelector) first."
-				
-				"mostRecentChangeSetWithChangeForClass: methodClass selector: methodSelector."
-			"aMethodBlock compiledMethod getSource asString allRangesOfRegexMatches: '(?<=activeIndex\: )\d*'."
-			"multiverse variants select: [:aVariant | aVariant containingArtefact = aMethodBlock]""]." 
+	(self onlySwitchedTabsIn: aMethodBlock multiverse: multiverse) ifTrue: [^ self].
+		
+	self updateInBackgroundOnTimeoutRevertTo: multiverse
 	
-	"updateProcessRunning ifTrue: [
+	 
+]
+
+{ #category : #'as yet unclassified' }
+SBExploriants >> updateInBackgroundOnTimeoutRevertTo: theOldMultiverse [
+
+	updateProcessRunning ifTrue: [
 		updateProcess ifNotNil: #terminate.
+		theOldMultiverse cleanUp.	
 		updateProcessRunning := false.].
 	
 	updateProcessRunning := true.
@@ -160,13 +182,16 @@ SBExploriants >> tryToUpdateInBackgroundAfterChangeIn: aMethodBlock [
 		self namedBlocks do: [:aTab | aTab multiverse: newMultiverse].
 		[newMultiverse kaboom] 
 			valueWithin: 5 seconds 
-			onTimeout: [
-				newMultiverse cleanUp. updateProcess := nil. updateProcessRunning := false.]. 
+			onTimeout: [newMultiverse cleanUp. 
+						  self namedBlocks do: [:aTab | aTab multiverse: theOldMultiverse]]. 
 		updateProcess := nil. updateProcessRunning := false.
-	] forkAt: Processor userBackgroundPriority."
+	] forkAt: Processor userBackgroundPriority.
+]
 
-	
-	
+{ #category : #'as yet unclassified' }
+SBExploriants >> updatePermutationStyling [
+
+	self namedBlocks do: #updatePermutationStyling
 ]
 
 { #category : #actions }

--- a/packages/Sandblocks-Babylonian/SBExploriants.class.st
+++ b/packages/Sandblocks-Babylonian/SBExploriants.class.st
@@ -45,7 +45,7 @@ SBExploriants >> = other [
 	^ self class = other class
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #callbacks }
 SBExploriants >> artefactSaved: aMethodBlock [
 
 	(aMethodBlock isMethod and: [self isInEditor]) ifTrue: [self tryToUpdateInBackgroundAfterChangeIn: aMethodBlock]
@@ -114,7 +114,7 @@ SBExploriants >> objectToPermutation [
 	^ objectToPermutation
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #actions }
 SBExploriants >> onlySwitchedTabsIn: aMethodBlock multiverse: aMultiverse [
 
 	| methodClass methodSelector latestChange diff changes |
@@ -155,7 +155,7 @@ SBExploriants >> selector [
 	^ nil
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #actions }
 SBExploriants >> tryToUpdateInBackgroundAfterChangeIn: aMethodBlock [
 
 	| multiverse |
@@ -167,7 +167,7 @@ SBExploriants >> tryToUpdateInBackgroundAfterChangeIn: aMethodBlock [
 	 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #actions }
 SBExploriants >> updateInBackgroundOnTimeoutRevertTo: theOldMultiverse [
 
 	updateProcessRunning ifTrue: [

--- a/packages/Sandblocks-Babylonian/SBExploriants.class.st
+++ b/packages/Sandblocks-Babylonian/SBExploriants.class.st
@@ -7,7 +7,8 @@ Class {
 	#instVars : [
 		'objectToPermutation',
 		'updateProcess',
-		'updateProcessRunning'
+		'updateProcessRunning',
+		'ignoreUpdate'
 	],
 	#classInstVars : [
 		'uniqueInstance'
@@ -88,6 +89,18 @@ SBExploriants >> evaluationReceiver [
 	^ self object
 ]
 
+{ #category : #accessing }
+SBExploriants >> ignoreUpdate [
+
+	^ ignoreUpdate
+]
+
+{ #category : #accessing }
+SBExploriants >> ignoreUpdate: aBoolean [
+
+	ignoreUpdate := aBoolean
+]
+
 { #category : #initialization }
 SBExploriants >> initialize [
 
@@ -114,34 +127,6 @@ SBExploriants >> objectToPermutation [
 	^ objectToPermutation
 ]
 
-{ #category : #actions }
-SBExploriants >> onlySwitchedTabsIn: aMethodBlock multiverse: aMultiverse [
-
-	| methodClass methodSelector latestChange diff changes |
-	(aMultiverse allMethodBlocksContainingVariants includes: aMethodBlock) 
-		ifFalse: [^ false].
-		
-	methodClass := aMethodBlock compiledMethod methodClass.
-	methodSelector := aMethodBlock compiledMethod selector.
-	latestChange := (ChangeSet 
-		scanVersionsOf: aMethodBlock compiledMethod
-		class: methodClass 
-		meta: methodClass isMeta
-		category: (methodClass organization categoryOfElement: methodSelector)
-		selector: methodSelector) second.
-	diff := TextDiffBuilder new
-		from: aMethodBlock compiledMethod getSource
-		to: latestChange text.
-	changes := OrderedCollection new.
-	diff patchSequenceDoIfMatch: [ :string |]
-			ifInsert: [ :string | changes add: string]
-			ifRemove: [ :string| changes add: string].
-	^ (changes allSatisfy: [:aString | aString matchesRegex: '\s*activeIndex\: \d*\s*']).
-		
-	
-	 
-]
-
 { #category : #'artefact protocol' }
 SBExploriants >> saveTryFixing: aFixBoolean quick: aQuickBoolean [
 
@@ -160,11 +145,12 @@ SBExploriants >> tryToUpdateInBackgroundAfterChangeIn: aMethodBlock [
 
 	| multiverse |
 	multiverse := self active multiverse.
-	(self onlySwitchedTabsIn: aMethodBlock multiverse: multiverse) 
-		ifTrue: [ [self sandblockEditor sendNewPermutationNotification] forkAt: Processor userBackgroundPriority.
-				^ self].
+	self ignoreUpdate 
+		ifFalse: [self updateInBackgroundOnTimeoutRevertTo: multiverse]
+		ifTrue: [
+		[self sandblockEditor sendNewPermutationNotification] forkAt: Processor userBackgroundPriority.
+		self ignoreUpdate: false.]
 		
-	self updateInBackgroundOnTimeoutRevertTo: multiverse
 	
 	 
 ]

--- a/packages/Sandblocks-Babylonian/SBExploriants.class.st
+++ b/packages/Sandblocks-Babylonian/SBExploriants.class.st
@@ -149,7 +149,7 @@ SBExploriants >> tryToUpdateInBackgroundAfterChangeIn: aMethodBlock [
 			"aMethodBlock compiledMethod getSource asString allRangesOfRegexMatches: '(?<=activeIndex\: )\d*'."
 			"multiverse variants select: [:aVariant | aVariant containingArtefact = aMethodBlock]""]." 
 	
-	updateProcessRunning ifTrue: [
+	"updateProcessRunning ifTrue: [
 		updateProcess ifNotNil: #terminate.
 		updateProcessRunning := false.].
 	
@@ -163,7 +163,7 @@ SBExploriants >> tryToUpdateInBackgroundAfterChangeIn: aMethodBlock [
 			onTimeout: [
 				newMultiverse cleanUp. updateProcess := nil. updateProcessRunning := false.]. 
 		updateProcess := nil. updateProcessRunning := false.
-	] forkAt: Processor userBackgroundPriority.
+	] forkAt: Processor userBackgroundPriority."
 
 	
 	

--- a/packages/Sandblocks-Babylonian/SBExploriants.class.st
+++ b/packages/Sandblocks-Babylonian/SBExploriants.class.st
@@ -181,17 +181,11 @@ SBExploriants >> updateInBackgroundOnTimeoutRevertTo: theOldMultiverse [
 		newMultiverse := SBMultiverse bigbangInEditorWithoutKaboom: self sandblockEditor.
 		self namedBlocks do: [:aTab | aTab multiverse: newMultiverse].
 		[newMultiverse kaboom] 
-			valueWithin: 5 seconds 
+			valueWithin: 7 seconds 
 			onTimeout: [newMultiverse cleanUp. 
 						  self namedBlocks do: [:aTab | aTab multiverse: theOldMultiverse]]. 
 		updateProcess := nil. updateProcessRunning := false.
 	] forkAt: Processor userBackgroundPriority.
-]
-
-{ #category : #'as yet unclassified' }
-SBExploriants >> updatePermutationStyling [
-
-	self namedBlocks do: #updatePermutationStyling
 ]
 
 { #category : #actions }

--- a/packages/Sandblocks-Babylonian/SBExploriants.class.st
+++ b/packages/Sandblocks-Babylonian/SBExploriants.class.st
@@ -5,7 +5,9 @@ Class {
 	#name : #SBExploriants,
 	#superclass : #SBTabView,
 	#instVars : [
-		'objectToPermutation'
+		'objectToPermutation',
+		'updateProcess',
+		'updateProcessRunning'
 	],
 	#classInstVars : [
 		'uniqueInstance'
@@ -41,6 +43,12 @@ SBExploriants class >> uniqueInstance [
 SBExploriants >> = other [
 
 	^ self class = other class
+]
+
+{ #category : #'as yet unclassified' }
+SBExploriants >> artefactSaved: aMethodBlock [
+
+	(aMethodBlock isMethod and: [self isInEditor]) ifTrue: [self tryToUpdateInBackgroundAfterChangeIn: aMethodBlock]
 ]
 
 { #category : #'ast helpers' }
@@ -86,6 +94,7 @@ SBExploriants >> initialize [
 	super initialize.
 	
 	objectToPermutation := WeakKeyDictionary new.
+	updateProcessRunning := false.
 	
 	self
 		attachDecorator: SBMoveDecorator new;
@@ -118,13 +127,55 @@ SBExploriants >> selector [
 	^ nil
 ]
 
+{ #category : #'as yet unclassified' }
+SBExploriants >> tryToUpdateInBackgroundAfterChangeIn: aMethodBlock [
+
+	| multiverse |
+	multiverse := self active multiverse.
+	"(multiverse allMethodBlocksContainingVariants includes: aMethodBlock) 
+		ifTrue: [ 
+			| methodClass methodSelector latestChange |
+			methodClass := aMethodBlock compiledMethod methodClass.
+			methodSelector := aMethodBlock compiledMethod selector.
+			self halt.
+			latestChange := (ChangeSet 
+				scanVersionsOf: aMethodBlock compiledMethod
+				class: methodClass 
+				meta: methodClass isMeta
+				category: (methodClass organization categoryOfElement: methodSelector)
+				selector: methodSelector) first."
+				
+				"mostRecentChangeSetWithChangeForClass: methodClass selector: methodSelector."
+			"aMethodBlock compiledMethod getSource asString allRangesOfRegexMatches: '(?<=activeIndex\: )\d*'."
+			"multiverse variants select: [:aVariant | aVariant containingArtefact = aMethodBlock]""]." 
+	
+	updateProcessRunning ifTrue: [
+		updateProcess ifNotNil: #terminate.
+		updateProcessRunning := false.].
+	
+	updateProcessRunning := true.
+	updateProcess := [
+		| newMultiverse |
+		newMultiverse := SBMultiverse bigbangInEditorWithoutKaboom: self sandblockEditor.
+		self namedBlocks do: [:aTab | aTab multiverse: newMultiverse].
+		[newMultiverse kaboom] 
+			valueWithin: 5 seconds 
+			onTimeout: [
+				newMultiverse cleanUp. updateProcess := nil. updateProcessRunning := false.]. 
+		updateProcess := nil. updateProcessRunning := false.
+	] forkAt: Processor userBackgroundPriority.
+
+	
+	
+]
+
 { #category : #actions }
 SBExploriants >> visualize [
 
 	| tabs |
 	self width: 0.
 	"tabs will visualize as soon as multiverse is finished"
-	tabs := SBExploriantsView getTabsInMultiverse: (SBMultiverse newInEditor: self sandblockEditor).
+	tabs := SBExploriantsView getTabsInMultiverse: (SBMultiverse bigbangInEditor: self sandblockEditor).
 	
 	self namedBlocks: tabs activeIndex: 1.
 	

--- a/packages/Sandblocks-Babylonian/SBExploriants.class.st
+++ b/packages/Sandblocks-Babylonian/SBExploriants.class.st
@@ -160,7 +160,9 @@ SBExploriants >> tryToUpdateInBackgroundAfterChangeIn: aMethodBlock [
 
 	| multiverse |
 	multiverse := self active multiverse.
-	(self onlySwitchedTabsIn: aMethodBlock multiverse: multiverse) ifTrue: [^ self].
+	(self onlySwitchedTabsIn: aMethodBlock multiverse: multiverse) 
+		ifTrue: [ [self sandblockEditor sendNewPermutationNotification] forkAt: Processor userBackgroundPriority.
+				^ self].
 		
 	self updateInBackgroundOnTimeoutRevertTo: multiverse
 	

--- a/packages/Sandblocks-Babylonian/SBExploriantsView.class.st
+++ b/packages/Sandblocks-Babylonian/SBExploriantsView.class.st
@@ -102,7 +102,7 @@ SBExploriantsView >> multiverse [
 SBExploriantsView >> multiverse: aSBMultiverse [
 
 	multiverse := aSBMultiverse.
-	multiverse when: #initialized send: #visualize to: self.
+	multiverse when: #updated send: #visualize to: self.
 ]
 
 { #category : #building }

--- a/packages/Sandblocks-Babylonian/SBExploriantsView.class.st
+++ b/packages/Sandblocks-Babylonian/SBExploriantsView.class.st
@@ -95,7 +95,7 @@ SBExploriantsView >> initialize [
 { #category : #accessing }
 SBExploriantsView >> multiverse [
 
-	^ multiverse ifNil: [self multiverse: (SBMultiverse newInEditor: SBEditor current)]
+	^ multiverse ifNil: [self multiverse: (SBMultiverse bigbangInEditor: SBEditor current)]
 ]
 
 { #category : #accessing }
@@ -121,7 +121,7 @@ SBExploriantsView >> updateButton [
 	^ SBButton new
 		icon: SBIcon iconRotateLeft
 			label: 'Re-Generate Multiverse'
-			do: [self multiverse initialize];
+			do: [self multiverse gatherElements; asyncKaboom];
 		cornerStyle: #squared
 ]
 

--- a/packages/Sandblocks-Babylonian/SBInactiveExampleWatch.class.st
+++ b/packages/Sandblocks-Babylonian/SBInactiveExampleWatch.class.st
@@ -23,6 +23,12 @@ SBInactiveExampleWatch class >> registerWatch: aWatch [
 	"we do not want the inactive watches in the registry"
 ]
 
+{ #category : #'event handling' }
+SBInactiveExampleWatch class >> unregisterWatch: aWatch [
+
+	"we do not want the inactive watches in the registry"
+]
+
 { #category : #callbacks }
 SBInactiveExampleWatch >> artefactSaved: aBlock [
 

--- a/packages/Sandblocks-Babylonian/SBInactiveExampleWatch.class.st
+++ b/packages/Sandblocks-Babylonian/SBInactiveExampleWatch.class.st
@@ -7,16 +7,6 @@ Class {
 	#category : #'Sandblocks-Babylonian'
 }
 
-{ #category : #'initialize-release' }
-SBInactiveExampleWatch class >> newFromWatch: anActiveWatch [
-
-	^ (anActiveWatch veryDeepCopy)
-		primitiveChangeClassTo: self basicNew;
-		expression: (SBTextBubble new contents: anActiveWatch cleanedExpression sourceString);
-		saveObjectsActivePermutations;
-		yourself 
-]
-
 { #category : #'event handling' }
 SBInactiveExampleWatch class >> registerWatch: aWatch [
 

--- a/packages/Sandblocks-Babylonian/SBInactiveExampleWatch.class.st
+++ b/packages/Sandblocks-Babylonian/SBInactiveExampleWatch.class.st
@@ -17,6 +17,12 @@ SBInactiveExampleWatch class >> newFromWatch: anActiveWatch [
 		yourself 
 ]
 
+{ #category : #'event handling' }
+SBInactiveExampleWatch class >> registerWatch: aWatch [
+
+	"we do not want the inactive watches in the registry"
+]
+
 { #category : #callbacks }
 SBInactiveExampleWatch >> artefactSaved: aBlock [
 

--- a/packages/Sandblocks-Babylonian/SBLiveView.class.st
+++ b/packages/Sandblocks-Babylonian/SBLiveView.class.st
@@ -39,7 +39,7 @@ SBLiveView >> buildPreviewFor: aPermutation [
 		addAllMorphsBack: {
 			self containerRow listDirection: #topToBottom;
 				 addAllMorphsBack: { 
-					SBOwnTextMorph new contents: aPermutation asString.
+					TextMorph new contents: aPermutation asStylizedText.
 					self newPermutationButtonRowFor: aPermutation showing: preview.
 					preview}.
 		LineMorph from: 0@0 to: 0@50 color: Color black width: 2}).

--- a/packages/Sandblocks-Babylonian/SBLiveView.class.st
+++ b/packages/Sandblocks-Babylonian/SBLiveView.class.st
@@ -39,7 +39,7 @@ SBLiveView >> buildPreviewFor: aPermutation [
 		addAllMorphsBack: {
 			self containerRow listDirection: #topToBottom;
 				 addAllMorphsBack: { 
-					TextMorph new contents: aPermutation asStylizedText.
+					SBPermutationLabel newDisplaying: aPermutation.
 					self newPermutationButtonRowFor: aPermutation showing: preview.
 					preview}.
 		LineMorph from: 0@0 to: 0@50 color: Color black width: 2}).

--- a/packages/Sandblocks-Babylonian/SBMultiverse.class.st
+++ b/packages/Sandblocks-Babylonian/SBMultiverse.class.st
@@ -109,15 +109,8 @@ SBMultiverse >> asyncKaboom [
 { #category : #actions }
 SBMultiverse >> cleanUp [
 	
-	self resetWatchesToOriginalPermutationRunning: activeExamples.
+	watches do: #resumeGraphicalUpdates.
 	(watches select: [:anOpenWatch | anOpenWatch containingArtefact isNil]) copy do: #delete
-]
-
-{ #category : #actions }
-SBMultiverse >> cleanUpRemovingCopies: outOfWorldWatches [
-	
-	self resetWatchesToOriginalPermutationRunning: activeExamples.
-	outOfWorldWatches copy do: #delete
 ]
 
 { #category : #collecting }
@@ -140,14 +133,15 @@ SBMultiverse >> gatherElements [
 	
 	allMethodBlocksContainingWatches := self allCompiledMethodsContainingExampleWatches collect: #asSandblock.
 	
+	universes := OrderedCollection new.
+	activeExamples := self allActiveExamples.
+	
 	variants := (allMethodBlocksContainingVariants collect: #containedVariants) flatten.
 	variants := variants select: #isActive.
 	
 	watches := (self allMethodBlocksContainingWatches collect: #containedExampleWatches) flatten.
-	
-	universes := OrderedCollection new.
-	activeExamples := self allActiveExamples.
-	
+	watches do: [:aWatch | activeExamples do: [:anExample | aWatch exampleStarting: anExample].
+							 aWatch hide].
 	
 ]
 
@@ -162,14 +156,22 @@ SBMultiverse >> initialize [
 { #category : #actions }
 SBMultiverse >> kaboom [
 	
-	| outOfWorldWatches |
+	| outOfWorldWatches permutations |
 	"Only open watches display values when examples are run. We want to show them too"
 	(outOfWorldWatches := watches reject: #isInEditor) do: [:aWatch | self sandblockEditor openMorph: aWatch].
+	permutations := (SBPermutation allPermutationsOf: variants).
+	watches do: #stopGraphicalUpdates.
 	
-	(SBPermutation allPermutationsOf: variants) do: [:aPermutation | 
+	"Running the active one last"
+	(permutations sorted: [:a :b | a activeScore  <= b activeScore ] ) do: [:aPermutation | 
 		self runPermutation: aPermutation copyingWatches: watches ].
-	self resetWatchesToOriginalPermutationRunning: activeExamples.
-	outOfWorldWatches copy do: #delete.
+	
+	"but stay consistent of the permutation sequences for alignment in clusters" 
+	"sorting this is cheaper than running a permutation twice just to reset to prior state"
+	universes := universes sorted: [:a :b | 
+		(permutations indexOf: a activePermutation) <= (permutations indexOf: b activePermutation)].
+	self cleanUp.
+	
 	self triggerEvent: #updated.
 ]
 
@@ -185,13 +187,6 @@ SBMultiverse >> reset [
 		collect: [:aPermutation | SBUniverse newActive: aPermutation watches: {}]) .
 	
 	self triggerEvent: #updated.
-]
-
-{ #category : #'action-helper' }
-SBMultiverse >> resetWatchesToOriginalPermutationRunning: activeExamples [
-
-	SBActiveVariantPermutation value: nil.
-	activeExamples do: #runSynchronouslyIgnoreReturn
 ]
 
 { #category : #actions }
@@ -214,10 +209,9 @@ SBMultiverse >> resolve [
 { #category : #actions }
 SBMultiverse >> runPermutation: aPermutation copyingWatches: allWatches [
 	
-	
 	SBActiveVariantPermutation value: aPermutation.
-	activeExamples do: #runSynchronouslyIgnoreReturn.
-	universes add: (SBUniverse newActive: aPermutation watches: (watches collect: #asInactiveCopy))
+	activeExamples do: [:anExample | anExample runSynchUpdatingOnlyValuesOf: allWatches].
+	universes add: (SBUniverse newActive: aPermutation watches: (allWatches collect: #asInactiveCopy))
 			
 ]
 

--- a/packages/Sandblocks-Babylonian/SBMultiverse.class.st
+++ b/packages/Sandblocks-Babylonian/SBMultiverse.class.st
@@ -107,7 +107,7 @@ SBMultiverse >> createUniverseFomPermutation: aSBPermutation [
 { #category : #collecting }
 SBMultiverse >> findExistingOrConvertToBlocks: aCollectionOfCompiledMethods [ 
 
-	^ aCollectionOfCompiledMethods
+	^ aCollectionOfCompiledMethods 
 		collect: [:aCompiledMethod | 
 			self sandblockEditor blockFor: aCompiledMethod withInterfaces: #(#isMethod) 
 				ifOpen: [:existingMethodBlock | existingMethodBlock] 
@@ -126,6 +126,8 @@ SBMultiverse >> gatherElements [
 	allMethodBlocksContainingWatches := self findExistingOrConvertToBlocks: self allCompiledMethodsContainingExampleWatches.
 	
 	variants := (allMethodBlocksContainingVariants collect: #containedVariants) flatten.
+	variants := variants select: #isActive.
+	
 	activeExamples := self allActiveExamples.
 	
 	

--- a/packages/Sandblocks-Babylonian/SBMultiverse.class.st
+++ b/packages/Sandblocks-Babylonian/SBMultiverse.class.st
@@ -89,13 +89,6 @@ SBMultiverse >> allMethodBlocksContainingWatches [
 
 ]
 
-{ #category : #collecting }
-SBMultiverse >> copyWatches [
-	
-	^ (self allMethodBlocksContainingWatches collect: [:aMethodBlock | 
-		aMethodBlock containedExampleWatches collect: #asInactiveCopy]) flatten
-]
-
 { #category : #converting }
 SBMultiverse >> createUniverseFomPermutation: aSBPermutation [ 
 
@@ -136,17 +129,23 @@ SBMultiverse >> gatherElements [
 { #category : #'initialize-release' }
 SBMultiverse >> initialize [ 
 
-	| permutations |
+	| permutations watches outOfWorldWatches |
 	super initialize.
 
 	self gatherElements.
 	
 	permutations := SBPermutation allPermutationsOf: variants.
 	universes := OrderedCollection new.
+	
+	watches := (self allMethodBlocksContainingWatches collect: #containedExampleWatches) flatten.
+	"Only open watches display values when examples are run. We want to show them too"
+	(outOfWorldWatches := watches reject: #isInEditor) do: [:aWatch | self sandblockEditor openMorph: aWatch].
+	
 	[permutations do: [:aPermutation |
 			SBActiveVariantPermutation value: aPermutation.
 			activeExamples do: #runSynchronouslyIgnoreReturn.
-			universes add: (self createUniverseFomPermutation: aPermutation)].
+			universes add: (SBUniverse newActive: aPermutation watches: (watches collect: #asInactiveCopy))].
+		outOfWorldWatches copy do: #delete.
 		self resetWatchesToOriginalPermutationRunning: activeExamples.
 		self triggerEvent: #updated] forkAt: Processor userSchedulingPriority.
 	

--- a/packages/Sandblocks-Babylonian/SBMultiverse.class.st
+++ b/packages/Sandblocks-Babylonian/SBMultiverse.class.st
@@ -148,9 +148,22 @@ SBMultiverse >> initialize [
 			activeExamples do: #runSynchronouslyIgnoreReturn.
 			universes add: (self createUniverseFomPermutation: aPermutation)].
 		self resetWatchesToOriginalPermutationRunning: activeExamples.
-		self triggerEvent: #initialized] forkAt: Processor userSchedulingPriority.
+		self triggerEvent: #updated] forkAt: Processor userSchedulingPriority.
 	
 	
+]
+
+{ #category : #actions }
+SBMultiverse >> reset [
+
+	allMethodBlocksContainingVariants := OrderedCollection new.
+	allMethodBlocksContainingWatches := OrderedCollection new.
+	variants := OrderedCollection new.
+	activeExamples := OrderedCollection new.
+	universes := OrderedCollection withAll: ((SBPermutation allPermutationsOf: {}) 
+		collect: [:aPermutation | self createUniverseFomPermutation: aPermutation]) .
+	
+	self triggerEvent: #updated.
 ]
 
 { #category : #state }
@@ -170,8 +183,10 @@ SBMultiverse >> resolve [
 		self saveMethod: aVariantMethod].
 	
 	(self findExistingOrConvertToBlocks: self allCompiledMethodsContainingExampleWatches) do: [:aWatchMethod | 
-		aWatchMethod  containedExampleWatches do: #replaceWithWatchedExpression.
+		aWatchMethod containedExampleWatches do: #replaceWithWatchedExpression.
 		self saveMethod: aWatchMethod].
+	
+	self reset.
 	
 ]
 

--- a/packages/Sandblocks-Babylonian/SBMultiverse.class.st
+++ b/packages/Sandblocks-Babylonian/SBMultiverse.class.st
@@ -7,6 +7,7 @@ Class {
 	#instVars : [
 		'universes',
 		'variants',
+		'watches',
 		'activeExamples',
 		'allMethodBlocksContainingVariants',
 		'allMethodBlocksContainingWatches',
@@ -16,19 +17,29 @@ Class {
 }
 
 { #category : #'instance creation' }
-SBMultiverse class >> new [
-	
-	"Use constructor with editor instead"
-	self shouldNotImplement 
+SBMultiverse class >> bigbangInEditor: aSandblockEditor [
+
+	^ self basicNew
+		sandblockEditor: aSandblockEditor;
+		initialize;
+		asyncKaboom;
+		yourself 
 ]
 
 { #category : #'instance creation' }
-SBMultiverse class >> newInEditor: aSandblockEditor [
+SBMultiverse class >> bigbangInEditorWithoutKaboom: aSandblockEditor [ 
 
 	^ self basicNew
 		sandblockEditor: aSandblockEditor;
 		initialize;
 		yourself 
+]
+
+{ #category : #'instance creation' }
+SBMultiverse class >> new [
+	
+	"Use constructor with editor instead"
+	self shouldNotImplement 
 ]
 
 { #category : #accessing }
@@ -89,12 +100,24 @@ SBMultiverse >> allMethodBlocksContainingWatches [
 
 ]
 
-{ #category : #converting }
-SBMultiverse >> createUniverseFomPermutation: aSBPermutation [ 
+{ #category : #actions }
+SBMultiverse >> asyncKaboom [
+	
+	^ [self kaboom] forkAt: Processor userSchedulingPriority.
+]
 
-	^ SBUniverse 
-		newActive: aSBPermutation
-		watches: self copyWatches
+{ #category : #actions }
+SBMultiverse >> cleanUp [
+	
+	self resetWatchesToOriginalPermutationRunning: activeExamples.
+	(watches select: [:anOpenWatch | anOpenWatch containingArtefact isNil]) copy do: #delete
+]
+
+{ #category : #actions }
+SBMultiverse >> cleanUpRemovingCopies: outOfWorldWatches [
+	
+	self resetWatchesToOriginalPermutationRunning: activeExamples.
+	outOfWorldWatches copy do: #delete
 ]
 
 { #category : #collecting }
@@ -115,12 +138,14 @@ SBMultiverse >> gatherElements [
 	have consistency between changes."
 	allMethodBlocksContainingVariants := self findExistingOrConvertToBlocks: self allCompiledMethodsContainingVariants.
 	
-	"We need existing originals to be noticed of changes."
-	allMethodBlocksContainingWatches := self findExistingOrConvertToBlocks: self allCompiledMethodsContainingExampleWatches.
+	allMethodBlocksContainingWatches := self allCompiledMethodsContainingExampleWatches collect: #asSandblock.
 	
 	variants := (allMethodBlocksContainingVariants collect: #containedVariants) flatten.
 	variants := variants select: #isActive.
 	
+	watches := (self allMethodBlocksContainingWatches collect: #containedExampleWatches) flatten.
+	
+	universes := OrderedCollection new.
 	activeExamples := self allActiveExamples.
 	
 	
@@ -129,27 +154,23 @@ SBMultiverse >> gatherElements [
 { #category : #'initialize-release' }
 SBMultiverse >> initialize [ 
 
-	| permutations watches outOfWorldWatches |
 	super initialize.
-
+	
 	self gatherElements.
+]
+
+{ #category : #actions }
+SBMultiverse >> kaboom [
 	
-	permutations := SBPermutation allPermutationsOf: variants.
-	universes := OrderedCollection new.
-	
-	watches := (self allMethodBlocksContainingWatches collect: #containedExampleWatches) flatten.
+	| outOfWorldWatches |
 	"Only open watches display values when examples are run. We want to show them too"
 	(outOfWorldWatches := watches reject: #isInEditor) do: [:aWatch | self sandblockEditor openMorph: aWatch].
 	
-	[permutations do: [:aPermutation |
-			SBActiveVariantPermutation value: aPermutation.
-			activeExamples do: #runSynchronouslyIgnoreReturn.
-			universes add: (SBUniverse newActive: aPermutation watches: (watches collect: #asInactiveCopy))].
-		outOfWorldWatches copy do: #delete.
-		self resetWatchesToOriginalPermutationRunning: activeExamples.
-		self triggerEvent: #updated] forkAt: Processor userSchedulingPriority.
-	
-	
+	(SBPermutation allPermutationsOf: variants) do: [:aPermutation | 
+		self runPermutation: aPermutation copyingWatches: watches ].
+	self resetWatchesToOriginalPermutationRunning: activeExamples.
+	outOfWorldWatches copy do: #delete.
+	self triggerEvent: #updated.
 ]
 
 { #category : #actions }
@@ -159,13 +180,14 @@ SBMultiverse >> reset [
 	allMethodBlocksContainingWatches := OrderedCollection new.
 	variants := OrderedCollection new.
 	activeExamples := OrderedCollection new.
+	watches:= OrderedCollection new.
 	universes := OrderedCollection withAll: ((SBPermutation allPermutationsOf: {}) 
-		collect: [:aPermutation | self createUniverseFomPermutation: aPermutation]) .
+		collect: [:aPermutation | SBUniverse newActive: aPermutation watches: {}]) .
 	
 	self triggerEvent: #updated.
 ]
 
-{ #category : #state }
+{ #category : #'action-helper' }
 SBMultiverse >> resetWatchesToOriginalPermutationRunning: activeExamples [
 
 	SBActiveVariantPermutation value: nil.
@@ -187,6 +209,16 @@ SBMultiverse >> resolve [
 	
 	self reset.
 	
+]
+
+{ #category : #actions }
+SBMultiverse >> runPermutation: aPermutation copyingWatches: allWatches [
+	
+	
+	SBActiveVariantPermutation value: aPermutation.
+	activeExamples do: #runSynchronouslyIgnoreReturn.
+	universes add: (SBUniverse newActive: aPermutation watches: (watches collect: #asInactiveCopy))
+			
 ]
 
 { #category : #accessing }
@@ -219,4 +251,10 @@ SBMultiverse >> universes [
 SBMultiverse >> variants [
 
 	^ variants
+]
+
+{ #category : #accessing }
+SBMultiverse >> watches [
+
+	^ watches
 ]

--- a/packages/Sandblocks-Babylonian/SBMultiverse.class.st
+++ b/packages/Sandblocks-Babylonian/SBMultiverse.class.st
@@ -141,7 +141,7 @@ SBMultiverse >> gatherElements [
 	
 	watches := (self allMethodBlocksContainingWatches collect: #containedExampleWatches) flatten.
 	watches do: [:aWatch | activeExamples do: [:anExample | aWatch exampleStarting: anExample].
-							 aWatch hide].
+							 aWatch hide. aWatch extent: 1@1].
 	
 ]
 

--- a/packages/Sandblocks-Babylonian/SBPermutationGridsView.class.st
+++ b/packages/Sandblocks-Babylonian/SBPermutationGridsView.class.st
@@ -17,7 +17,7 @@ SBPermutationGridsView >> buildPermutationFor: aSBUniverse [
 		addAllMorphsBack: {
 			self containerRow listDirection: #topToBottom;
 				addAllMorphsBack: { 
-					TextMorph new contents: aSBUniverse activePermutation asStylizedText.
+					SBPermutationLabel newDisplaying: aSBUniverse activePermutation.
 					SBButton newApplyPermutationFor: aSBUniverse activePermutation. 
 					(SBPermutationCluster 
 						newForSize: morphResizer

--- a/packages/Sandblocks-Babylonian/SBPermutationGridsView.class.st
+++ b/packages/Sandblocks-Babylonian/SBPermutationGridsView.class.st
@@ -17,7 +17,7 @@ SBPermutationGridsView >> buildPermutationFor: aSBUniverse [
 		addAllMorphsBack: {
 			self containerRow listDirection: #topToBottom;
 				addAllMorphsBack: { 
-					SBOwnTextMorph new contents: aSBUniverse activePermutation asString.
+					TextMorph new contents: aSBUniverse activePermutation asStylizedText.
 					SBButton newApplyPermutationFor: aSBUniverse activePermutation. 
 					(SBPermutationCluster 
 						newForSize: morphResizer

--- a/packages/Sandblocks-Babylonian/SBPermutationLabel.class.st
+++ b/packages/Sandblocks-Babylonian/SBPermutationLabel.class.st
@@ -1,0 +1,43 @@
+Class {
+	#name : #SBPermutationLabel,
+	#superclass : #TextMorph,
+	#instVars : [
+		'permutation'
+	],
+	#category : #'Sandblocks-Babylonian'
+}
+
+{ #category : #'as yet unclassified' }
+SBPermutationLabel class >> newDisplaying: aSBPermutation [
+
+	^ self new
+		permutation: aSBPermutation;
+		updateStyling;
+		yourself
+]
+
+{ #category : #'*Sandblocks-Babylonian' }
+SBPermutationLabel >> listensToPermutations [
+
+	^ true
+]
+
+{ #category : #accessing }
+SBPermutationLabel >> permutation [
+
+	^ permutation
+]
+
+{ #category : #accessing }
+SBPermutationLabel >> permutation: aSBPermutation [
+
+	permutation := aSBPermutation.
+	
+	self updateStyling
+]
+
+{ #category : #accessing }
+SBPermutationLabel >> updateStyling [
+
+	self contents: self permutation asStylizedText 
+]

--- a/packages/Sandblocks-Babylonian/SBPermutationLabel.class.st
+++ b/packages/Sandblocks-Babylonian/SBPermutationLabel.class.st
@@ -17,7 +17,7 @@ SBPermutationLabel class >> newDisplaying: aSBPermutation [
 ]
 
 { #category : #'*Sandblocks-Babylonian' }
-SBPermutationLabel >> listensToPermutations [
+SBPermutationLabel >> listensToPermutations [ 
 
 	^ true
 ]

--- a/packages/Sandblocks-Babylonian/SBPermutationLabel.extension.st
+++ b/packages/Sandblocks-Babylonian/SBPermutationLabel.extension.st
@@ -1,7 +1,7 @@
 Extension { #name : #SBPermutationLabel }
 
 { #category : #'*Sandblocks-Babylonian' }
-SBPermutationLabel >> listensToPermutations [
+SBPermutationLabel >> listensToPermutations [ 
 
 	^ true
 ]

--- a/packages/Sandblocks-Babylonian/SBPermutationLabel.extension.st
+++ b/packages/Sandblocks-Babylonian/SBPermutationLabel.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #SBPermutationLabel }
+
+{ #category : #'*Sandblocks-Babylonian' }
+SBPermutationLabel >> listensToPermutations [
+
+	^ true
+]

--- a/packages/Sandblocks-Babylonian/SBPlainResultsView.class.st
+++ b/packages/Sandblocks-Babylonian/SBPlainResultsView.class.st
@@ -13,7 +13,7 @@ SBPlainResultsView >> buildAllPossibleResults [
 { #category : #building }
 SBPlainResultsView >> buildPermutationFor: aSBUniverse [
 
-	self block addAllMorphsBack: { SBOwnTextMorph new contents: aSBUniverse activePermutation asString.
+	self block addAllMorphsBack: { TextMorph new contents: aSBUniverse activePermutation asStylizedText .
 									SBButton newApplyPermutationFor: aSBUniverse activePermutation.
 									(self containerRow listDirection: #leftToRight) 
 										addAllMorphsBack: aSBUniverse watches.

--- a/packages/Sandblocks-Babylonian/SBPlainResultsView.class.st
+++ b/packages/Sandblocks-Babylonian/SBPlainResultsView.class.st
@@ -13,7 +13,7 @@ SBPlainResultsView >> buildAllPossibleResults [
 { #category : #building }
 SBPlainResultsView >> buildPermutationFor: aSBUniverse [
 
-	self block addAllMorphsBack: { TextMorph new contents: aSBUniverse activePermutation asStylizedText .
+	self block addAllMorphsBack: {SBPermutationLabel newDisplaying: aSBUniverse activePermutation.
 									SBButton newApplyPermutationFor: aSBUniverse activePermutation.
 									(self containerRow listDirection: #leftToRight) 
 										addAllMorphsBack: aSBUniverse watches.

--- a/packages/Sandblocks-Babylonian/SBResultsView.class.st
+++ b/packages/Sandblocks-Babylonian/SBResultsView.class.st
@@ -21,13 +21,6 @@ SBResultsView >> initialize [
 	morphResizer := SBMorphResizer newThumbmail.
 ]
 
-{ #category : #building }
-SBResultsView >> resetWatchesToOriginalPermutationRunning: activeExamples [
-
-	SBActiveVariantPermutation value: nil.
-	activeExamples do: #runSynchronouslyIgnoreReturn
-]
-
 { #category : #actions }
 SBResultsView >> visualize [ 
 

--- a/packages/Sandblocks-Babylonian/SBStGrammarHandler.extension.st
+++ b/packages/Sandblocks-Babylonian/SBStGrammarHandler.extension.st
@@ -24,6 +24,7 @@ SBStGrammarHandler >> addExample: anExample [
 		
 	anExample startRunning.
 	self block sandblockEditor select: anExample nameBlock.
+	self block sandblockEditor save: method tryFixing: true quick: false.
 ]
 
 { #category : #'*Sandblocks-Babylonian' }

--- a/packages/Sandblocks-Core/SBBlock.class.st
+++ b/packages/Sandblocks-Core/SBBlock.class.st
@@ -2586,7 +2586,7 @@ SBBlock >> sandblockForegroundColor [
 { #category : #'artefact protocol' }
 SBBlock >> save [
 
-	(self saveTryFixing: false quick: false) ifFalse: [self error: 'failed to save block']
+	(self saveTryFixing: false quick: false) 
 ]
 
 { #category : #saving }

--- a/packages/Sandblocks-Core/SBGrammarHandler.class.st
+++ b/packages/Sandblocks-Core/SBGrammarHandler.class.st
@@ -194,7 +194,9 @@ SBGrammarHandler >> watchWith: aWatchClass [
 	self block sandblockEditor do: (SBWrapCommand new
 		outer: aWatchClass new newIdentifier;
 		inner: self block;
-		wrap: [:outer :inner | outer expression: inner])
+		wrap: [:outer :inner | outer expression: inner]).
+		
+	self block sandblockEditor save: self block containingArtefact tryFixing: true quick: false.
 ]
 
 { #category : #'callback helpers' }

--- a/packages/Sandblocks-Core/SBLabel.class.st
+++ b/packages/Sandblocks-Core/SBLabel.class.st
@@ -131,7 +131,11 @@ SBLabel >> initialize [
 		layoutInset: 0;
 		addMorphBack: (text := SBMultilineOwnTextMorph new
 			emphasis: TextEmphasis italic;
-			maxWidth: 550);
+			maxWidth: 550;
+			when: #doubleClicked
+			send: #triggerEvent:
+			to: self
+			with: #doubleClicked);
 		headingLevel: 0
 ]
 

--- a/packages/Sandblocks-Core/SBTabView.class.st
+++ b/packages/Sandblocks-Core/SBTabView.class.st
@@ -142,6 +142,14 @@ SBTabView >> addTab [
 	self add: (self active veryDeepCopy name: self activeName, '_i')
 ]
 
+{ #category : #'submorphs - enumerating' }
+SBTabView >> allMorphsDepthFirstDo: aBlock [ 
+
+	submorphs do: [:m | m allMorphsDepthFirstDo: aBlock].
+	(self namedBlocks reject: [:m | m = self active]) do: [:m | m block allMorphsDepthFirstDo: aBlock].
+	aBlock value: self
+]
+
 { #category : #ui }
 SBTabView >> asTabButton: aNamedBlock [
 

--- a/packages/Sandblocks-Core/SBTabView.class.st
+++ b/packages/Sandblocks-Core/SBTabView.class.st
@@ -170,6 +170,14 @@ SBTabView >> asTabButton: aNamedBlock [
 	^ button
 ]
 
+{ #category : #tabs }
+SBTabView >> basicSetActive: aNamedBlock [
+
+	self sandblockEditor do: 
+		(self switchCommandFor: (self namedBlocks indexOf: aNamedBlock ifAbsent: 1)).
+	
+]
+
 { #category : #accessing }
 SBTabView >> blockAt: anIndex [
 
@@ -387,8 +395,13 @@ SBTabView >> removeCurrentTab [
 { #category : #tabs }
 SBTabView >> setActive: aNamedBlock [
 
-	self sandblockEditor do: 
-		(self switchCommandFor: (self namedBlocks indexOf: aNamedBlock ifAbsent: 1))
+	(self containingArtefact hasUnsavedChanges and: [self containingArtefact isMethod])
+		ifTrue: [self basicSetActive: aNamedBlock] 
+		ifFalse: ["changing tabs is latest change"
+			self basicSetActive: aNamedBlock.
+			SBExploriants uniqueInstance ignoreUpdate: true.
+			self sandblockEditor save: self containingArtefact  tryFixing: false quick: true.].
+	
 ]
 
 { #category : #commands }

--- a/packages/Sandblocks-Core/SBUnknown.class.st
+++ b/packages/Sandblocks-Core/SBUnknown.class.st
@@ -9,6 +9,12 @@ Class {
 	#category : #'Sandblocks-Core'
 }
 
+{ #category : #'as yet unclassified' }
+SBUnknown class >> registerShortcuts: aProvider [
+
+	aProvider shortcut: $" do: #titleSection
+]
+
 { #category : #'text input' }
 SBUnknown >> acceptCharacter: aCharacter [
 

--- a/packages/Sandblocks-Core/SBVimInputMapping.class.st
+++ b/packages/Sandblocks-Core/SBVimInputMapping.class.st
@@ -150,7 +150,7 @@ SBVimInputMapping >> registerDefaultShortcuts [
 		registerShortcut: Character cr do: #insertStatementBelow;
 
 		" smalltalk "
-		cmdShortcut: $" do: #wrapInToggledCode;
+		cmdShortcut: $" do: #wrapInOptinalVariant;
 		cmdShortcut: $Q do: #wrapInVariant;
 		cmdShortcut: $D do: #insertLabelAbove;
 		cmdShortcut: $b do: #insertHaltBelow;

--- a/packages/Sandblocks-Morphs/SBButton.class.st
+++ b/packages/Sandblocks-Morphs/SBButton.class.st
@@ -18,7 +18,8 @@ SBButton class >> newApplyPermutationFor: aPermutation [
 				size: 8.0 sbScaled;
 				color: (Color r: 0.0 g: 1 b: 0.0))
 			label: 'Apply'
-			do: [aPermutation apply];
+			do: [aPermutation apply.
+				self sandblockEditor sendNewPermutationNotification];
 		makeSmall;
 		cornerStyle: #squared
 ]

--- a/packages/Sandblocks-Morphs/SBButton.class.st
+++ b/packages/Sandblocks-Morphs/SBButton.class.st
@@ -18,8 +18,7 @@ SBButton class >> newApplyPermutationFor: aPermutation [
 				size: 8.0 sbScaled;
 				color: (Color r: 0.0 g: 1 b: 0.0))
 			label: 'Apply'
-			do: [aPermutation apply.
-				self sandblockEditor sendNewPermutationNotification];
+			do: [aPermutation apply];
 		makeSmall;
 		cornerStyle: #squared
 ]

--- a/packages/Sandblocks-Smalltalk/SBStGrammarHandler.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStGrammarHandler.class.st
@@ -340,6 +340,32 @@ SBStGrammarHandler >> suggestionsFor: aBlock [
 	^ #()
 ]
 
+{ #category : #actions }
+SBStGrammarHandler >> titleSection [
+	<multiSelectAction>
+	<actionValidIf: #isUnknown>
+
+	| variant |
+	self assert: self block isSelected.
+	variant := SBVariant new.
+	self block sandblockEditor multiSelectionIsConsecutive ifFalse: [^ self].
+	self block sandblockEditor doMultiSelection: [:selected |
+		SBWrapConsecutiveCommand new
+			selectAfter: #block;
+			outer: variant;
+			targets: selected;
+			wrap:  [:outer :inner |
+				variant 
+					named: inner printString 
+					alternatives: {SBNamedBlock 
+						block: (SBStBlockBody new statements: inner) 
+						named: 'current'.}
+					activeIndex: 1];
+			yourself].
+		
+		self block sandblockEditor select: variant nameBlock.
+]
+
 { #category : #'action helpers' }
 SBStGrammarHandler >> useArgument: aNumber [
 

--- a/packages/Sandblocks-Smalltalk/SBStGrammarHandler.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStGrammarHandler.class.st
@@ -612,7 +612,10 @@ SBStGrammarHandler >> wrapInOptionalVariant [
 					named: inner printString 
 					alternatives: (self defaultOptionalAlternativesForBlocks: inner)
 					activeIndex: 2];
-			yourself]
+			yourself].
+		
+	variant sandblockEditor select: variant nameBlock.
+	variant sandblockEditor save: variant containingArtefact tryFixing: true quick: false.
 ]
 
 { #category : #actions }
@@ -666,7 +669,10 @@ SBStGrammarHandler >> wrapInVariant [
 					named: inner printString 
 					alternatives: (self defaultAlternativesForBlocks: inner)
 					activeIndex: 2];
-			yourself]
+			yourself].
+		
+	variant sandblockEditor select: variant nameBlock.
+	variant sandblockEditor save: variant containingArtefact tryFixing: true quick: false.
 ]
 
 { #category : #actions }

--- a/packages/Sandblocks-Smalltalk/SBVariant.class.st
+++ b/packages/Sandblocks-Smalltalk/SBVariant.class.st
@@ -4,7 +4,8 @@ Class {
 	#instVars : [
 		'name',
 		'widget',
-		'id'
+		'id',
+		'isActive'
 	],
 	#category : #'Sandblocks-Smalltalk'
 }
@@ -39,7 +40,7 @@ SBVariant class >> matches: aBlock [
 { #category : #constants }
 SBVariant class >> matchingSelectors [
 
-	^ #(#named:associations:activeIndex:id:)
+	^ #(#named:associations:activeIndex:id:isActive:)
 ]
 
 { #category : #'instance creation' }
@@ -64,14 +65,28 @@ SBVariant class >> named: aString alternatives: aCollectionOfNamedBlocks activeI
 ]
 
 { #category : #'instance creation' }
-SBVariant class >> named: aString associations: aCollectionOfAssociations activeIndex: aNumber id: uuid [
+SBVariant class >> named: aString alternatives: aCollectionOfNamedBlocks activeIndex: aNumber id: uuid isActive: aBoolean [
+
+	^ self new
+		named: aString
+		alternatives: aCollectionOfNamedBlocks
+		activeIndex: aNumber
+		id: uuid
+		isActive: aBoolean
+		
+]
+
+{ #category : #'instance creation' }
+SBVariant class >> named: aString associations: aCollectionOfAssociations activeIndex: aNumber id: uuid isActive: aBoolean [
 
 	| defaultBehavior requestor requiredPermutation |
 	aNumber <= 0 ifTrue: [^ nil].
+	defaultBehavior := (aCollectionOfAssociations at: aNumber) value value.
+	"Inactive variants ignore any active or dynamic permutation shenanigans"
+	aBoolean ifFalse: [^ defaultBehavior].
+	
 	"Always prioritize the permutation which is marked as active"
 	SBActiveVariantPermutation value ifNotNil: [^ (aCollectionOfAssociations at: (SBActiveVariantPermutation value at: uuid)) value value].
-	
-	defaultBehavior := (aCollectionOfAssociations at: aNumber) value value.
 	
 	"The requesting object does not require dynamic update behavior in which it needs to know a certain alternative"
 	SBExploriants objectToPermutation at: (requestor := thisContext sender receiver) ifAbsent: [^ defaultBehavior].
@@ -97,6 +112,7 @@ SBVariant class >> newFor: aBlock [
 		alternatives: (aBlock arguments second childSandblocks collect: [:anAssociation | SBNamedBlock block: (anAssociation arguments first) named: (anAssociation receiver contents)])
 		activeIndex: aBlock arguments third parsedContents
 		id: aBlock arguments fourth contents
+		isActive: aBlock arguments fifth contents = 'true'
 ]
 
 { #category : #shortcuts }
@@ -128,6 +144,17 @@ SBVariant >> activeBlock [
 SBVariant >> activeIndex [
 
 	^ self widget activeIndex
+]
+
+{ #category : #actions }
+SBVariant >> activeMutateCommandWithNewValue: aBoolean [
+
+	^ SBMutatePropertyCommand new
+		target: self;
+		selector: #isActive;
+		mutateSelector: #isActive:;
+		value: aBoolean;
+		oldValue: self isActive
 ]
 
 { #category : #accessing }
@@ -184,6 +211,34 @@ SBVariant >> asProxy [
 	^ SBVariantProxy for: self
 ]
 
+{ #category : #actions }
+SBVariant >> beActive [
+	<action>
+
+	| command |
+	command := self activeMutateCommandWithNewValue: true.
+	
+	self sandblockEditor 
+		ifNil: [command do] 
+		ifNotNil:[:theEditor | theEditor do: command].
+		
+	self saveArtefact.
+]
+
+{ #category : #actions }
+SBVariant >> beInactive [
+	<action>
+
+	| command |
+	command := self activeMutateCommandWithNewValue: false.
+	
+	self sandblockEditor 
+		ifNil: [command do] 
+		ifNotNil:[:theEditor | theEditor do: command].
+		
+	self saveArtefact.
+]
+
 { #category : #accessing }
 SBVariant >> blockAt: anIndex [
 
@@ -194,12 +249,6 @@ SBVariant >> blockAt: anIndex [
 SBVariant >> color [
 
 	^ Color transparent
-]
-
-{ #category : #accessing }
-SBVariant >> drawnColor [
-
-	^ Color white
 ]
 
 { #category : #accessing }
@@ -226,6 +275,7 @@ SBVariant >> initialize [
 		namedBlocks: {SBNamedBlock block: (SBStBlockBody emptyWithDeclarations: {'a'. 'c'}) named: 'Code'}
 		activeIndex: 1).
 	id := UUID new asString. 
+	isActive := true.
 	
 	self
 		layoutInset: 0;
@@ -235,6 +285,23 @@ SBVariant >> initialize [
 		addAllMorphsBack: {name . widget};
 		vResizing: #shrinkWrap;
 		hResizing: #shrinkWrap
+]
+
+{ #category : #accessing }
+SBVariant >> isActive [
+
+	^ isActive
+]
+
+{ #category : #accessing }
+SBVariant >> isActive: aBoolean [
+
+	isActive := aBoolean.
+	
+	isActive 
+		ifTrue:  [self localColorPolicy: SBEditor defaultColorPolicy new]
+		ifFalse: [self localColorPolicy: SBDisabledTheme new.
+				self activeBlock localColorPolicy: SBEditor defaultColorPolicy new.]
 ]
 
 { #category : #testing }
@@ -267,6 +334,13 @@ SBVariant >> named: aString alternatives: aCollectionOfNamedBlocks activeIndex: 
 
 	self id: uuid.
 	self named: aString alternatives: aCollectionOfNamedBlocks activeIndex: aNumber
+]
+
+{ #category : #initialization }
+SBVariant >> named: aString alternatives: aCollectionOfNamedBlocks activeIndex: aNumber id: uuid isActive: aBoolean [
+
+	self isActive: aBoolean.
+	self named: aString alternatives: aCollectionOfNamedBlocks activeIndex: aNumber id: uuid
 ]
 
 { #category : #accessing }
@@ -316,6 +390,14 @@ SBVariant >> replaceValuesFrom: anotherVariant [
 	self named: anotherVariant name alternatives: anotherVariant alternatives activeIndex: anotherVariant activeIndex  
 ]
 
+{ #category : #actions }
+SBVariant >> saveArtefact [
+
+	self containingArtefact save.
+	self containingArtefact sandblockEditor ifNotNil: [:theEditor | theEditor markSaved: self containingArtefact]
+	
+]
+
 { #category : #accessing }
 SBVariant >> statementsFor: aNamedBlock [
 
@@ -328,6 +410,12 @@ SBVariant >> statementsFor: aNamedBlock [
 SBVariant >> switchToAlternative: anIndex [
 
 	self widget jumpToTab: anIndex
+]
+
+{ #category : #accessing }
+SBVariant >> toggleActive [
+
+	isActive := isActive not
 ]
 
 { #category : #ui }
@@ -371,5 +459,7 @@ SBVariant >> writeSourceOn: aStream [
 	self activeIndex storeOn: aStream.
 	aStream nextPutAll: ' id: '.
 	self id storeOn: aStream.
+	aStream nextPutAll: ' isActive: '.
+	self isActive storeOn: aStream.
 	aStream nextPutAll: ')'
 ]

--- a/packages/Sandblocks-Smalltalk/SBVariant.class.st
+++ b/packages/Sandblocks-Smalltalk/SBVariant.class.st
@@ -222,7 +222,7 @@ SBVariant >> beActive [
 		ifNil: [command do] 
 		ifNotNil:[:theEditor | theEditor do: command].
 		
-	self saveArtefact.
+	self containingArtefact sandblockEditor save: self containingArtefact tryFixing: true quick: false.
 ]
 
 { #category : #actions }
@@ -236,7 +236,7 @@ SBVariant >> beInactive [
 		ifNil: [command do] 
 		ifNotNil:[:theEditor | theEditor do: command].
 		
-	self saveArtefact.
+	self containingArtefact sandblockEditor save: self containingArtefact tryFixing: true quick: false.
 ]
 
 { #category : #accessing }
@@ -417,14 +417,6 @@ SBVariant >> replaceSelfWithLabel [
 SBVariant >> replaceValuesFrom: anotherVariant [
 
 	self named: anotherVariant name alternatives: anotherVariant alternatives activeIndex: anotherVariant activeIndex  
-]
-
-{ #category : #actions }
-SBVariant >> saveArtefact [
-
-	self containingArtefact save.
-	self containingArtefact sandblockEditor ifNotNil: [:theEditor | theEditor markSaved: self containingArtefact]
-	
 ]
 
 { #category : #accessing }

--- a/packages/Sandblocks-Smalltalk/SBVariant.class.st
+++ b/packages/Sandblocks-Smalltalk/SBVariant.class.st
@@ -266,11 +266,11 @@ SBVariant >> initialize [
 
 	super initialize.
 	
-	name := SBLabel new
+	self nameBlock: (SBLabel new
 		text: (SBOwnTextMorph new
 			emphasis: TextEmphasis italic;
 			small);
-		contents: 'Variant X'.
+		contents: 'Variant X').
 	self widget: (SBDiffTabView
 		namedBlocks: {SBNamedBlock block: (SBStBlockBody emptyWithDeclarations: {'a'. 'c'}) named: 'Code'}
 		activeIndex: 1).
@@ -301,7 +301,8 @@ SBVariant >> isActive: aBoolean [
 	isActive 
 		ifTrue:  [self localColorPolicy: SBEditor defaultColorPolicy new]
 		ifFalse: [self localColorPolicy: SBDisabledTheme new.
-				self activeBlock localColorPolicy: SBEditor defaultColorPolicy new.]
+				self namedBlocks do: [:aBlock | 
+					aBlock block localColorPolicy: SBEditor defaultColorPolicy new]]
 ]
 
 { #category : #testing }
@@ -320,6 +321,20 @@ SBVariant >> name [
 SBVariant >> name: aString [
 
 	name contents: aString
+]
+
+{ #category : #accessing }
+SBVariant >> nameBlock [
+
+	^ name
+]
+
+{ #category : #accessing }
+SBVariant >> nameBlock: aSBLabel [
+
+	name := aSBLabel.
+	
+	name when: #doubleClicked send: #replaceSelfWithLabel to: self.
 ]
 
 { #category : #initialization }
@@ -384,6 +399,20 @@ SBVariant >> replaceSelfWithChosen [
 		ifNotNil:[:theEditor | theEditor do: command]
 ]
 
+{ #category : #actions }
+SBVariant >> replaceSelfWithLabel [ 
+	
+	<action>
+	| command |
+	command :=  SBReplaceCommand new 
+						target: self; 
+						replacer: (SBLabel new contents: self name).
+	
+	self sandblockEditor 
+		ifNil: [command do] 
+		ifNotNil:[:theEditor | theEditor do: command]
+]
+
 { #category : #initialization }
 SBVariant >> replaceValuesFrom: anotherVariant [
 
@@ -415,7 +444,9 @@ SBVariant >> switchToAlternative: anIndex [
 { #category : #accessing }
 SBVariant >> toggleActive [
 
-	isActive := isActive not
+	self isActive 
+		ifTrue: [self beInactive] 
+		ifFalse: [self beActive]
 ]
 
 { #category : #ui }

--- a/packages/Sandblocks-Utils/SBPermutation.class.st
+++ b/packages/Sandblocks-Utils/SBPermutation.class.st
@@ -40,6 +40,14 @@ SBPermutation class >> newCombinedOf: onePermutation and: anotherPermutation [
 	
 ]
 
+{ #category : #accessing }
+SBPermutation >> activeScore [
+
+	^ (self referencedVariants collect: [:aVariant |
+		aVariant activeIndex = (self at: aVariant id) ifTrue: [1] ifFalse: [0]]) 
+		inject: 0 into: [:a :c | a + c]
+]
+
 { #category : #actions }
 SBPermutation >> apply [
 
@@ -58,6 +66,24 @@ SBPermutation >> asString [
 			fold: [:a :b | a, ', ', b ]
 
 	
+]
+
+{ #category : #converting }
+SBPermutation >> asStylizedText [
+
+	| text |
+	text := Text fromString: self asString.
+	^ self isActive
+		ifTrue: [text allBold] 
+		ifFalse: [text]
+
+	
+]
+
+{ #category : #accessing }
+SBPermutation >> isActive [
+
+	^ self activeScore = self referencedVariants size
 ]
 
 { #category : #accessing }

--- a/packages/Sandblocks-Utils/SBPermutation.class.st
+++ b/packages/Sandblocks-Utils/SBPermutation.class.st
@@ -54,6 +54,9 @@ SBPermutation >> apply [
 	self referencedVariants do: [:aVariant | aVariant switchToAlternative: (self at: aVariant id)].
 	(Set newFrom: (referencedVariants collect: #containingArtefact thenSelect: #isMethod))
 		do: [:aMethodBlock | aMethodBlock sandblockEditor save: aMethodBlock tryFixing: true quick: true].
+	((Set newFrom: (referencedVariants collect: #sandblockEditor))
+		reject: #isNil)
+		do: #sendNewPermutationNotification
 ]
 
 { #category : #converting }

--- a/packages/Sandblocks-Utils/SBPermutation.class.st
+++ b/packages/Sandblocks-Utils/SBPermutation.class.st
@@ -52,8 +52,6 @@ SBPermutation >> activeScore [
 SBPermutation >> apply [
 
 	self referencedVariants do: [:aVariant | aVariant switchToAlternative: (self at: aVariant id)].
-	(Set newFrom: (referencedVariants collect: #containingArtefact thenSelect: #isMethod))
-		do: [:aMethodBlock | aMethodBlock sandblockEditor save: aMethodBlock tryFixing: true quick: true].
 	((Set newFrom: (referencedVariants collect: #sandblockEditor))
 		reject: #isNil)
 		do: #sendNewPermutationNotification

--- a/packages/Sandblocks-Watch/SBExampleWatchView.class.st
+++ b/packages/Sandblocks-Watch/SBExampleWatchView.class.st
@@ -40,6 +40,5 @@ SBExampleWatchView >> reportValues: aCollectionOfObjects sized: aMorphResizer [
 SBExampleWatchView >> updateDisplay [
 
 	super updateDisplay.
-	
-	self count: (watchValues size) asString
+	self count: (watchValues size) asString.
 ]

--- a/packages/Sandblocks-Watch/SBWatchView.class.st
+++ b/packages/Sandblocks-Watch/SBWatchView.class.st
@@ -142,7 +142,11 @@ SBWatchView >> displayWatchValues [
 { #category : #accessing }
 SBWatchView >> displayedMorphs [
 
-	^ self scroller submorphs first "container for scrolling" submorphs 
+	^ self scroller submorphs 
+			ifEmpty: [{}]
+			ifNotEmpty: [:valueContainer | valueContainer first "container for scrolling" submorphs ]
+	
+		
 ]
 
 { #category : #'event handling' }

--- a/packages/Sandblocks-Watch/SBWatchView.class.st
+++ b/packages/Sandblocks-Watch/SBWatchView.class.st
@@ -264,7 +264,7 @@ SBWatchView >> printOn: aStream [
 { #category : #actions }
 SBWatchView >> reportValue: anObject [
 
-	self reportValue: {anObject} sized: SBMorphResizer newIdentity
+	self reportValues: {anObject} sized: SBMorphResizer newIdentity
 ]
 
 { #category : #actions }

--- a/packages/Sandblocks-Watch/SBWatchView.class.st
+++ b/packages/Sandblocks-Watch/SBWatchView.class.st
@@ -11,7 +11,8 @@ Class {
 		'count',
 		'clear',
 		'fallbackResizer',
-		'updateScheduled'
+		'updateScheduled',
+		'shouldUpdateDisplay'
 	],
 	#category : #'Sandblocks-Watch'
 }
@@ -135,7 +136,8 @@ SBWatchView >> displayWatchValues [
 	| valuesMorph |
 	valuesMorph := self watchValuesContainer.
 	valuesMorph addAllMorphsBack: (watchValues collect: #asValueMorph).
-
+	"Will sometimes not update size otherwise when rushing through runs"
+	valuesMorph doLayoutSafely.
 	self displayOnScrollPane: valuesMorph.
 ]
 
@@ -197,6 +199,7 @@ SBWatchView >> initialize [
 	numSavedValues := 1.
 	watchValues := LinkedList new.
 	fallbackResizer := SBMorphResizer newSmall.
+	shouldUpdateDisplay := true.
 	
 	self
 		layoutPolicy: SBAlgebraLayout new;
@@ -284,13 +287,21 @@ SBWatchView >> reportValues: aCollectionOfObjects sized: aMorphResizer [
 ]
 
 { #category : #actions }
+SBWatchView >> resetOnlyValues [
+	"Private"
+
+	count contents: '0'.
+	watchValues := LinkedList new.
+]
+
+{ #category : #actions }
 SBWatchView >> resizeThrough: aMorphResizer [
 
 	"Clearing everything here as Morphs get distorted when resized multiple times."
 	| valuesMorph |
 	valuesMorph := self watchValuesContainer.
-	valuesMorph addAllMorphsBack: (self displayedMorphs 
-		collect: #sbSnapshot 
+	valuesMorph addAllMorphsBack: (self displayedMorphs  
+		collect: #sbSnapshot   
 		thenDo: [:aMorph | aMorphResizer applyOn: aMorph]).
 
 	self displayOnScrollPane: valuesMorph.
@@ -315,6 +326,18 @@ SBWatchView >> scroller [
 	^ self scrollPane scroller
 ]
 
+{ #category : #accessing }
+SBWatchView >> shouldUpdateDisplay [
+
+	^ shouldUpdateDisplay
+]
+
+{ #category : #accessing }
+SBWatchView >> shouldUpdateDisplay: aBoolean [
+	
+	shouldUpdateDisplay := aBoolean
+]
+
 { #category : #'object interface' }
 SBWatchView >> storeAsExample [
 
@@ -330,6 +353,7 @@ SBWatchView >> storeAsExample [
 SBWatchView >> updateDisplay [
 
 	updateScheduled ifFalse: [^ self].
+	shouldUpdateDisplay ifFalse: [^ self].
 	
 	updateScheduled := false.
 	
@@ -366,6 +390,12 @@ SBWatchView >> veryDeepCopyWith: deepCopier [
 SBWatchView >> watchObjectInterface [
 
 	^ SBInterfaces topLevel, {[:o | o isEditor not]}
+]
+
+{ #category : #accessing }
+SBWatchView >> watchValues [
+	
+	^ watchValues
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Ignore branch name, fixed now ;)

Part 2 of #138 with following features:

- Variants can be turned inactive through the context menu and will be ignored when generating the multiverse
- Builds upon the concept of naming variants by creating "commented sections" on default when commenting. This is none other than a variant with one alternative. That way, variant usage is encouraged and cleanup of comments easier as they can be resolved by resolving the variant or using exploriant's cleanup. Double clicking the name will result in the block resolving to a SBLabel, to still enable conventional comments for e.g. documentation. 
- Exploriants now displays watches even though they are not open in the editor
- Some more automatic method saves when adding live elements, which is done equally in traditional babylonian
- Updates the way watch values are collected. Instead of running examples, updating the displays of watches', and collecting the submorphs, the visual displays are static and only internal values updated. The copies display themselves using the internal copied values. Now, there is no more flickering when generating the multiverse which is a no go for the biggest new feature in this MR:
- When exploriants is open and a method is saved, the multiverse will automatically try to collect its data in the background. When it succeeds in 7 seconds, Exploriants will update itself visually. By doing so users no longer have to spam the 'Generate Multiverse' button after each method save. This behavior is also more close to the idea of liveness. A future todo can include a progress bar in exploriants and having some kind of visual feedback when the current display is not uptodate since generation took longer. 


Again, divided by commits