### PR TITLE
History Tab in Exploriants, Tab Renaming, Space compression

### DIFF
--- a/packages/Sandblocks-Babylonian/SBCluster.class.st
+++ b/packages/Sandblocks-Babylonian/SBCluster.class.st
@@ -11,13 +11,7 @@ Class {
 SBCluster >> compressedMorphsForDisplay: aSBWatchView [
 
 	| displayedMorphs |
-	aSBWatchView isDisplayingWatchValues 
-		ifTrue: [displayedMorphs := self gatherAndCopyWatchValuesFrom: aSBWatchView]
-		ifFalse: [ | display |
-			display := aSBWatchView selectedDisplay submorphs 
-				ifEmpty: [aSBWatchView selectedDisplay]  
-				ifNotEmpty: [:submorphs | submorphs last].
-			displayedMorphs := {self morphResizer applyOn: display}].
+	displayedMorphs  := self gatherMorphsToCompressFrom: aSBWatchView.
 	^ (displayedMorphs size = 1) 
 		ifTrue: [displayedMorphs first]
 		ifFalse: [self newCellMorph 
@@ -29,11 +23,13 @@ SBCluster >> compressedMorphsForDisplay: aSBWatchView [
 ]
 
 { #category : #visualisation }
-SBCluster >> gatherAndCopyWatchValuesFrom: aSBWatchView [
+SBCluster >> gatherMorphsToCompressFrom: aSBWatchView [
 
-	^ aSBWatchView watchValues collect: [:aWatchValue | 
-			aWatchValue morphResizer: self morphResizer. 
-			aWatchValue asValueMorph]
+	^ aSBWatchView isDisplayingWatchValues 
+		ifTrue: [aSBWatchView watchValues collect: [:aWatchValue | 
+					aWatchValue morphResizer: self morphResizer. 
+					aWatchValue asValueMorph]]
+		ifFalse: [{self morphResizer applyOn: aSBWatchView selectedDisplay sbSnapshot }]
 ]
 
 { #category : #initialization }

--- a/packages/Sandblocks-Babylonian/SBCluster.class.st
+++ b/packages/Sandblocks-Babylonian/SBCluster.class.st
@@ -11,9 +11,13 @@ Class {
 SBCluster >> compressedMorphsForDisplay: aSBWatchView [
 
 	| displayedMorphs |
-	displayedMorphs := aSBWatchView watchValues collect: [:aWatchValue | 
-			aWatchValue morphResizer: self morphResizer. 
-			aWatchValue asValueMorph].
+	aSBWatchView isDisplayingWatchValues 
+		ifTrue: [displayedMorphs := self gatherAndCopyWatchValuesFrom: aSBWatchView]
+		ifFalse: [ | display |
+			display := aSBWatchView selectedDisplay submorphs 
+				ifEmpty: [aSBWatchView selectedDisplay]  
+				ifNotEmpty: [:submorphs | submorphs last].
+			displayedMorphs := {self morphResizer applyOn: display}].
 	^ (displayedMorphs size = 1) 
 		ifTrue: [displayedMorphs first]
 		ifFalse: [self newCellMorph 
@@ -22,6 +26,14 @@ SBCluster >> compressedMorphsForDisplay: aSBWatchView [
 					listDirection: #leftToRight;
 					wrapDirection: #topToBottom;
 					addAllMorphsBack: displayedMorphs]
+]
+
+{ #category : #visualisation }
+SBCluster >> gatherAndCopyWatchValuesFrom: aSBWatchView [
+
+	^ aSBWatchView watchValues collect: [:aWatchValue | 
+			aWatchValue morphResizer: self morphResizer. 
+			aWatchValue asValueMorph]
 ]
 
 { #category : #initialization }
@@ -177,7 +189,7 @@ SBCluster >> wrapInCell: aMorph flexVertically: aVBoolean flexHorizontally: aHBo
 	
 	self flag: #todo. "Another way besides turning into an image to keep interactions.-jb"
 	cell addMorph: (ImageMorph new 
-		newForm: (aMorph iconOrThumbnailOfSize: targetExtent);
+		newForm: (aMorph imageForm scaledIntoFormOfSize: targetExtent);
 		when: #clicked send: #triggerEvent: to: aMorph with: #clicked).
 	cell on: #click send: #value to: [cell submorphs first triggerEvent: #clicked].
 	^ cell

--- a/packages/Sandblocks-Babylonian/SBDiffTabView.class.st
+++ b/packages/Sandblocks-Babylonian/SBDiffTabView.class.st
@@ -103,6 +103,7 @@ SBDiffTabView >> initialize [
 	super initialize.
 	
 	isShowingDiff := false.
+	self hResizing: #spaceFill.
 ]
 
 { #category : #accessing }

--- a/packages/Sandblocks-Babylonian/SBExampleCluster.class.st
+++ b/packages/Sandblocks-Babylonian/SBExampleCluster.class.st
@@ -55,8 +55,8 @@ SBExampleCluster >> displayedIndex: aNumber [
 { #category : #visualisation }
 SBExampleCluster >> extractRowsFrom: aUniverse [
 
-	^ aUniverse watches collect: [:anExample | | display | 
-		display := (anExample exampleToDisplay associations at: self displayedIndex) value display.
+	^ aUniverse watches collect: [:aWatch | | display | 
+		display := (aWatch exampleToDisplay associations at: self displayedIndex) value display.
 		self compressedMorphsForDisplay: display]
 ]
 

--- a/packages/Sandblocks-Babylonian/SBExampleGridsView.class.st
+++ b/packages/Sandblocks-Babylonian/SBExampleGridsView.class.st
@@ -36,12 +36,6 @@ SBExampleGridsView >> currentClusterClass [
 		ifFalse: [SBExampleCluster]
 ]
 
-{ #category : #updating }
-SBExampleGridsView >> gridSize [
-
-	^ self multiverse activeExamples size
-]
-
 { #category : #initialization }
 SBExampleGridsView >> initialize [ 
 

--- a/packages/Sandblocks-Babylonian/SBExampleGridsView.class.st
+++ b/packages/Sandblocks-Babylonian/SBExampleGridsView.class.st
@@ -8,7 +8,8 @@ Class {
 SBExampleGridsView >> buildAllPossibleResults [
 	
 	self multiverse activeExamples 
-		ifEmpty: [gridContainer addMorph: (SBOwnTextMorph new contents: 'No examples active')].
+		ifEmpty: [gridContainer addMorph: (TextMorph new contents: 'No examples active').
+				  gridContainer width: gridContainer firstSubmorph width + 5 "a bit of margin"].
 	
 	self multiverse activeExamples withIndexDo: [:anExample :anIndex | self buildExampleFor: anIndex]
 ]
@@ -24,10 +25,7 @@ SBExampleGridsView >> buildExampleFor: aNumber [
 					self currentClusterClass
 						newForSize: self selectedResizer
 						multiverse: self multiverse 
-						displaying: aNumber}.
-		LineMorph from: 0@0 to: 0@50 color: Color black width: 2}).
-		
-	self updateContainerWidth.
+						displaying: aNumber}})
 ]
 
 { #category : #accessing }
@@ -49,5 +47,5 @@ SBExampleGridsView >> initialize [
 
 	super initialize.
 	
-	self name: 'Example Grid View'.
+	self name: 'Example Focused'.
 ]

--- a/packages/Sandblocks-Babylonian/SBExampleValueDisplay.class.st
+++ b/packages/Sandblocks-Babylonian/SBExampleValueDisplay.class.st
@@ -30,6 +30,7 @@ SBExampleValueDisplay >> display [
 { #category : #accessing }
 SBExampleValueDisplay >> displayedWatchValueBlocks [
 
+	display isDisplayingWatchValues ifFalse: [^ {}].
 	^ display displayedMorphs
 ]
 
@@ -82,7 +83,7 @@ SBExampleValueDisplay >> initialize [
 							statusLabel := SBStringMorph new contents: ''.
 							self newChangeVizButton};
 							yourself);
-		addMorphBack: (display := SBExampleWatch watchViewClass saving: -1)
+		addMorphBack: (display := SBExampleWatch watchViewClass new)
 ]
 
 { #category : #accessing }

--- a/packages/Sandblocks-Babylonian/SBExampleWatch.class.st
+++ b/packages/Sandblocks-Babylonian/SBExampleWatch.class.st
@@ -131,13 +131,32 @@ SBExampleWatch >> asInactiveCopy [
 				modifyExpression: self modifyExpression veryDeepCopy;
 				dimensionOptions: self dimensionOptions veryDeepCopy. 
 				
-	exampleToValues keys do: [:anExample |	copy exampleStarting: anExample;
-													   reportValues: (self valuesForExample: anExample) for: anExample;
-													   exampleFinished: anExample ].
+	exampleToValues keys do: [:anExample |	
+			copy exampleStarting: anExample;
+			reportValues: (self valuesForExample: anExample) for: anExample].
+												
+	"Keep switched views consistent"
+	exampleToDisplay keys do: [:anExample | 
+		(copy exampleToDisplay at: anExample) display 
+			selectedDisplayIndex: (exampleToDisplay at: anExample) display selectedDisplayIndex].		
+			
+	exampleToValues keys do: [:anExample |	copy exampleFinished: anExample].							
+	
 												
 	^ copy 
 		saveObjectsActivePermutations;
 		yourself
+]
+
+{ #category : #initialization }
+SBExampleWatch >> buildDefaultDisplayFor: anExample [
+
+	| valueDisplay |
+	valueDisplay := SBExampleValueDisplay new.
+	valueDisplay display fallbackResizer: self selectedMorphResizer.
+	self addMorph: (exampleToDisplay at: anExample put: valueDisplay) atIndex: 2.
+	anExample when: #outOfWorld send: #exampleStopped: to: self with: anExample.
+	^ valueDisplay
 ]
 
 { #category : #accessing }
@@ -167,6 +186,14 @@ SBExampleWatch >> cleanedExpression [
 SBExampleWatch >> color [
 
 	^ self parentSandblock color
+]
+
+{ #category : #copying }
+SBExampleWatch >> copySelectedDisplayIndicesFrom: other [
+
+	other exampleToDisplay associationsDo: [:exampleToDisplayAss | 
+		(exampleToDisplay at: exampleToDisplayAss key ifAbsentPut: [self buildDefaultDisplayFor: exampleToDisplayAss key])
+			display selectedDisplayIndex: exampleToDisplayAss value display selectedDisplayIndex]
 ]
 
 { #category : #'insert/delete' }
@@ -220,12 +247,7 @@ SBExampleWatch >> exampleStarting: anExample [
 
 	exampleToValues at: anExample put: OrderedCollection new.
 
-	(exampleToDisplay at: anExample ifAbsentPut: [ | valueDisplay |
-		valueDisplay := SBExampleValueDisplay new.
-		valueDisplay display fallbackResizer: self selectedMorphResizer.
-		self addMorph: (exampleToDisplay at: anExample put: valueDisplay) atIndex: 2.
-		anExample when: #outOfWorld send: #exampleStopped: to: self with: anExample.
-		valueDisplay])
+	(exampleToDisplay at: anExample ifAbsentPut: [self buildDefaultDisplayFor: anExample])
 		exampleStarting: anExample;
 		name: anExample label
 ]

--- a/packages/Sandblocks-Babylonian/SBExampleWatch.class.st
+++ b/packages/Sandblocks-Babylonian/SBExampleWatch.class.st
@@ -251,6 +251,12 @@ SBExampleWatch >> exampleToDisplay: anExampleToDisplayDict [
 ]
 
 { #category : #accessing }
+SBExampleWatch >> exampleToValues [
+
+	^ exampleToValues
+]
+
+{ #category : #accessing }
 SBExampleWatch >> exampleToValues: anExampleToCollectionOfWatchValuesDict [
 
 	exampleToValues := anExampleToCollectionOfWatchValuesDict

--- a/packages/Sandblocks-Babylonian/SBExploriantsView.class.st
+++ b/packages/Sandblocks-Babylonian/SBExploriantsView.class.st
@@ -17,7 +17,7 @@ SBExploriantsView class >> block: aSBBlock named: aString [
 { #category : #'instance creation' }
 SBExploriantsView class >> getTabsInMultiverse: aSBMultiverse [
 
-	^ {SBPermutationGridsView. SBExampleGridsView. SBPlainResultsView. SBLiveView. SBVariantsView}
+	^ {SBPermutationGridsView. SBExampleGridsView. SBLiveView. SBPlainResultsView. SBVariantsView. SBHistoryView}
 		collect: [:mySubclass | mySubclass newMultiverse: aSBMultiverse]
 ]
 
@@ -60,9 +60,9 @@ SBExploriantsView >> containerRow [
 		cellPositioning: #topLeft;
 		changeTableLayout;
 		listDirection: #leftToRight;
-		layoutInset: 8;
-		cellGap: 3;
-		cellInset: 3;
+		layoutInset: 2;
+		cellGap: 1;
+		cellInset: 2;
 		borderWidth: 0
 ]
 
@@ -113,6 +113,13 @@ SBExploriantsView >> resolveButton [
 			label: 'Resolve All From Code'
 			do: [self multiverse resolve];
 		cornerStyle: #squared
+]
+
+{ #category : #copying }
+SBExploriantsView >> snapshot [
+
+	"Return a collection of morphs which capture the current state of this view"
+	^ self subclassResponsibility 
 ]
 
 { #category : #building }

--- a/packages/Sandblocks-Babylonian/SBExploriantsView.class.st
+++ b/packages/Sandblocks-Babylonian/SBExploriantsView.class.st
@@ -118,8 +118,7 @@ SBExploriantsView >> resolveButton [
 { #category : #copying }
 SBExploriantsView >> snapshot [
 
-	"Return a collection of morphs which capture the current state of this view"
-	^ self subclassResponsibility 
+	^ ImageMorph new newForm: self block imageForm
 ]
 
 { #category : #building }
@@ -138,4 +137,11 @@ SBExploriantsView >> visualize [
 	self clean.
 
 	self buildButtonRow
+]
+
+{ #category : #copying }
+SBExploriantsView >> wantsHistory [
+	
+	"If returning true, will be automatically collected for an epoche in the history view"
+	^ true
 ]

--- a/packages/Sandblocks-Babylonian/SBGrid.class.st
+++ b/packages/Sandblocks-Babylonian/SBGrid.class.st
@@ -10,7 +10,7 @@ Class {
 { #category : #constants }
 SBGrid class >> cellInsetValue [
 
-	^ 2
+	^ 0
 ]
 
 { #category : #'initialize-release' }

--- a/packages/Sandblocks-Babylonian/SBGridResultsView.class.st
+++ b/packages/Sandblocks-Babylonian/SBGridResultsView.class.st
@@ -17,6 +17,44 @@ SBGridResultsView >> clean [
 ]
 
 { #category : #updating }
+SBGridResultsView >> concludeContainerWidth [
+	
+	| widthTillWrap |
+	widthTillWrap := self multiverse sandblockEditor width * 0.9.
+	gridContainer fullBounds width < widthTillWrap ifTrue: [^ self]. 
+	
+	self descentToScreenRatioMaxWidth: widthTillWrap.
+	
+	gridContainer hResizing: #shrinkWrap.
+]
+
+{ #category : #updating }
+SBGridResultsView >> descentToScreenRatioMaxWidth: maxWidth [
+
+	| editorRatio submorphIndex |
+	gridContainer hResizing: #rigid; wrapDirection: #topToBottom.
+	editorRatio := DisplayScreen boundingBox width /  DisplayScreen boundingBox height.
+	submorphIndex := gridContainer submorphs size.
+	
+	[gridContainer fullBounds width / gridContainer height > editorRatio 
+		and: [submorphIndex > 1]]
+		whileTrue: [ | isBelowMax |
+			isBelowMax := gridContainer width < maxWidth.
+			gridContainer width: gridContainer width 
+								- (gridContainer submorphs atWrap:  submorphIndex) width.
+				
+			(editorRatio > 1 
+			and: [gridContainer fullBounds height >= gridContainer width]
+			and: [isBelowMax])
+				ifTrue: [ gridContainer width: gridContainer width 
+											+(gridContainer submorphs atWrap:  submorphIndex) width.
+						submorphIndex := -1]
+				ifFalse: [submorphIndex := submorphIndex - 1]].
+				
+	gridContainer width > maxWidth ifTrue: [gridContainer width: maxWidth]
+]
+
+{ #category : #updating }
 SBGridResultsView >> gridSize [
 
 	self subclassResponsibility 
@@ -37,22 +75,16 @@ SBGridResultsView >> newGridContainer [
 		changeTableLayout;
 		color: Color white;
 		listDirection: #leftToRight;
-		wrapDirection: #topToBottom;
 		wrapCentering: #topLeft;
-		hResizing: #rigid;
-		width: 50;
 		cellInset: 0;
 		vResizing: #shrinkWrap;
+		hResizing: #shrinkWrap;
 		yourself
 ]
 
-{ #category : #updating }
-SBGridResultsView >> updateContainerWidth [
+{ #category : #actions }
+SBGridResultsView >> visualize [ 
 
-	gridContainer width: 
-		(self gridSize safeSquareRoot ceiling + 1)
-			* (gridContainer lastSubmorph fullBounds width 
-				+ (2 * gridContainer cellInset) 
-				+ (2 * gridContainer cellGap) 
-				+ 10)
+	super visualize.
+	self concludeContainerWidth
 ]

--- a/packages/Sandblocks-Babylonian/SBGridResultsView.class.st
+++ b/packages/Sandblocks-Babylonian/SBGridResultsView.class.st
@@ -23,41 +23,9 @@ SBGridResultsView >> concludeContainerWidth [
 	widthTillWrap := self multiverse sandblockEditor width * 0.9.
 	gridContainer fullBounds width < widthTillWrap ifTrue: [^ self]. 
 	
-	self descentToScreenRatioMaxWidth: widthTillWrap.
-	
-	gridContainer hResizing: #shrinkWrap.
-]
-
-{ #category : #updating }
-SBGridResultsView >> descentToScreenRatioMaxWidth: maxWidth [
-
-	| editorRatio submorphIndex |
 	gridContainer hResizing: #rigid; wrapDirection: #topToBottom.
-	editorRatio := DisplayScreen boundingBox width /  DisplayScreen boundingBox height.
-	submorphIndex := gridContainer submorphs size.
-	
-	[gridContainer fullBounds width / gridContainer height > editorRatio 
-		and: [submorphIndex > 1]]
-		whileTrue: [ | isBelowMax |
-			isBelowMax := gridContainer width < maxWidth.
-			gridContainer width: gridContainer width 
-								- (gridContainer submorphs atWrap:  submorphIndex) width.
-				
-			(editorRatio > 1 
-			and: [gridContainer fullBounds height >= gridContainer width]
-			and: [isBelowMax])
-				ifTrue: [ gridContainer width: gridContainer width 
-											+(gridContainer submorphs atWrap:  submorphIndex) width.
-						submorphIndex := -1]
-				ifFalse: [submorphIndex := submorphIndex - 1]].
-				
-	gridContainer width > maxWidth ifTrue: [gridContainer width: maxWidth]
-]
-
-{ #category : #updating }
-SBGridResultsView >> gridSize [
-
-	self subclassResponsibility 
+	gridContainer width: widthTillWrap.
+	gridContainer hResizing: #shrinkWrap.
 ]
 
 { #category : #initialization }

--- a/packages/Sandblocks-Babylonian/SBGridResultsView.class.st
+++ b/packages/Sandblocks-Babylonian/SBGridResultsView.class.st
@@ -20,7 +20,7 @@ SBGridResultsView >> clean [
 SBGridResultsView >> concludeContainerWidth [
 	
 	| widthTillWrap |
-	widthTillWrap := self multiverse sandblockEditor width * 0.9.
+	widthTillWrap := self multiverse sandblockEditor width * 0.95.
 	gridContainer fullBounds width < widthTillWrap ifTrue: [^ self]. 
 	
 	gridContainer hResizing: #rigid; wrapDirection: #topToBottom.

--- a/packages/Sandblocks-Babylonian/SBHistoryView.class.st
+++ b/packages/Sandblocks-Babylonian/SBHistoryView.class.st
@@ -31,7 +31,8 @@ SBHistoryView >> buildMetaUsageIn: aRow [
 	^ self containerRow
 		cellGap: 5@0;
 		addAllMorphsBack: {self deleteEpocheButton: aRow. 
-								TextMorph new contents: (Text fromString: TimeStamp current asStringOrText) allBold}
+								TextMorph new contents: (Text fromString: TimeStamp current asStringOrText) allBold.
+								SBLabel new contents: 'Notes'}
 	
 	
 ]
@@ -40,9 +41,8 @@ SBHistoryView >> buildMetaUsageIn: aRow [
 SBHistoryView >> buildSnapshotTabView [
 
 	^ SBTabView 
-		namedBlocks: (SBExploriants uniqueInstance namedBlocks 
-							select: #wantsHistory 
-							thenCollect: [:aTab | SBNamedBlock block: aTab snapshot named: aTab name]) 
+		namedBlocks: (self tabsToSnapshot
+							collect: [:aTab | SBNamedBlock block: aTab snapshot named: aTab name]) 
 		activeIndex: (SBExploriants uniqueInstance active wantsHistory
 							ifTrue: [SBExploriants uniqueInstance activeIndex] 
 							 ifFalse: [1])
@@ -52,7 +52,17 @@ SBHistoryView >> buildSnapshotTabView [
 { #category : #building }
 SBHistoryView >> buttons [
 
-	^ super buttons, {self clearButton}
+	^ super buttons, {self clearButton. self changeTabsButton. self saveButton }
+]
+
+{ #category : #building }
+SBHistoryView >> changeTabsButton [
+
+	^ SBButton new
+		icon: SBIcon iconTable
+			label: 'Change All Tabs To'
+			do: [self offerChangeTabMenu];
+		cornerStyle: #squared
 ]
 
 { #category : #building }
@@ -63,12 +73,6 @@ SBHistoryView >> clearButton [
 			label: 'Clear History'
 			do: [self clean. self block addMorphBack: self buildButtonRow];
 		cornerStyle: #squared
-]
-
-{ #category : #building }
-SBHistoryView >> collectSnapshots [
-
-	^ (SBExploriants uniqueInstance namedBlocks collect: [:aView | aView snapshot]) flatten
 ]
 
 { #category : #building }
@@ -97,6 +101,33 @@ SBHistoryView >> initialize [
 SBHistoryView >> maxEpoches [
 
 	^ 100
+]
+
+{ #category : #building }
+SBHistoryView >> offerChangeTabMenu [
+
+	| index options |
+	options := self tabsToSnapshot collect: #name.
+	index := UIManager default chooseFrom: options.
+	index = 0 ifTrue: [^ self].
+	
+	self block submorphs allButFirst do: [:anEpoche | anEpoche lastSubmorph activeIndex: index].
+]
+
+{ #category : #building }
+SBHistoryView >> saveButton [
+
+	^ SBButton new
+		icon: SBIcon iconSave
+			label: 'Save As PNG'
+			do: [self block exportAsPNG];
+		cornerStyle: #squared
+]
+
+{ #category : #accessing }
+SBHistoryView >> tabsToSnapshot [
+
+	^ SBExploriants uniqueInstance namedBlocks select: #wantsHistory
 ]
 
 { #category : #actions }

--- a/packages/Sandblocks-Babylonian/SBHistoryView.class.st
+++ b/packages/Sandblocks-Babylonian/SBHistoryView.class.st
@@ -1,0 +1,96 @@
+Class {
+	#name : #SBHistoryView,
+	#superclass : #SBExploriantsView,
+	#category : #'Sandblocks-Babylonian'
+}
+
+{ #category : #building }
+SBHistoryView >> addEpoche [
+
+	self submorphs size - 1 "buttonRow" > self maxEpoches ifTrue: [self lastSubmorph delete]. 
+	
+	self block addMorph: self buildEpoche atIndex: 2
+]
+
+{ #category : #building }
+SBHistoryView >> buildEpoche [
+
+	| row |
+	row := self containerRow.
+	^ row
+		cellGap: 0@10; 
+		listDirection: #topToBottom;
+		addMorphBack: (self containerRow
+							cellGap: 5@0;
+							addMorphBack: (self deleteEpocheButton: row); 
+							addMorphBack: TimeStamp current asMorph);
+		addMorphBack: (self containerRow
+							layoutInset: 0;
+							cellGap: 0;
+							cellInset: 0; 
+							addAllMorphsBack:  self collectSnapshots)
+	
+	
+]
+
+{ #category : #building }
+SBHistoryView >> buttons [
+
+	^ super buttons, {self clearButton}
+]
+
+{ #category : #building }
+SBHistoryView >> clearButton [
+
+	^ SBButton new
+		icon: SBIcon iconClockO
+			label: 'Clear History'
+			do: [self clean. self block addMorphBack: self buildButtonRow];
+		cornerStyle: #squared
+]
+
+{ #category : #building }
+SBHistoryView >> collectSnapshots [
+
+	^ (SBExploriants uniqueInstance namedBlocks collect: [:aView | aView snapshot]) flatten
+]
+
+{ #category : #building }
+SBHistoryView >> deleteEpocheButton: theRow [
+
+	^ SBButton new
+		icon: SBIcon iconTrash
+			do: [theRow delete];
+		balloonText: 'Delete this row';
+		cornerStyle: #squared;
+		makeSmall
+	
+	
+]
+
+{ #category : #initialization }
+SBHistoryView >> initialize [ 
+
+	super initialize.
+	
+	self name: 'History'.
+	self buildButtonRow.
+]
+
+{ #category : #accessing }
+SBHistoryView >> maxEpoches [
+
+	^ 100
+]
+
+{ #category : #copying }
+SBHistoryView >> snapshot [ 
+
+	^ {}
+]
+
+{ #category : #actions }
+SBHistoryView >> visualize [ 
+
+	self addEpoche
+]

--- a/packages/Sandblocks-Babylonian/SBHistoryView.class.st
+++ b/packages/Sandblocks-Babylonian/SBHistoryView.class.st
@@ -20,16 +20,32 @@ SBHistoryView >> buildEpoche [
 	^ row
 		cellGap: 0@10; 
 		listDirection: #topToBottom;
-		addMorphBack: (self containerRow
-							cellGap: 5@0;
-							addMorphBack: (self deleteEpocheButton: row); 
-							addMorphBack: TimeStamp current asMorph);
-		addMorphBack: (self containerRow
-							layoutInset: 0;
-							cellGap: 0;
-							cellInset: 0; 
-							addAllMorphsBack:  self collectSnapshots)
+		addAllMorphsBack: {self buildMetaUsageIn: row. self buildSnapshotTabView}
 	
+	
+]
+
+{ #category : #building }
+SBHistoryView >> buildMetaUsageIn: aRow [
+
+	^ self containerRow
+		cellGap: 5@0;
+		addAllMorphsBack: {self deleteEpocheButton: aRow. 
+								TextMorph new contents: (Text fromString: TimeStamp current asStringOrText) allBold}
+	
+	
+]
+
+{ #category : #building }
+SBHistoryView >> buildSnapshotTabView [
+
+	^ SBTabView 
+		namedBlocks: (SBExploriants uniqueInstance namedBlocks 
+							select: #wantsHistory 
+							thenCollect: [:aTab | SBNamedBlock block: aTab snapshot named: aTab name]) 
+		activeIndex: (SBExploriants uniqueInstance active wantsHistory
+							ifTrue: [SBExploriants uniqueInstance activeIndex] 
+							 ifFalse: [1])
 	
 ]
 
@@ -83,14 +99,14 @@ SBHistoryView >> maxEpoches [
 	^ 100
 ]
 
-{ #category : #copying }
-SBHistoryView >> snapshot [ 
-
-	^ {}
-]
-
 { #category : #actions }
 SBHistoryView >> visualize [ 
 
 	self addEpoche
+]
+
+{ #category : #copying }
+SBHistoryView >> wantsHistory [
+	
+	^ false
 ]

--- a/packages/Sandblocks-Babylonian/SBLiveView.class.st
+++ b/packages/Sandblocks-Babylonian/SBLiveView.class.st
@@ -87,12 +87,6 @@ SBLiveView >> evaluateSetUp [
 	^ return
 ]
 
-{ #category : #updating }
-SBLiveView >> gridSize [
-	
-	^ self multiverse universes size + 1
-]
-
 { #category : #initialization }
 SBLiveView >> initialize [ 
 
@@ -205,8 +199,12 @@ SBLiveView >> setUpMorph [
 
 { #category : #copying }
 SBLiveView >> snapshot [
-
-	^ {ImageMorph new newForm: gridContainer imageForm}
+						
+	^ self containerRow 
+				listDirection: #topToBottom;
+				addAllMorphsBack: {
+					ImageMorph new newForm: (self block submorphNamed: 'setup') imageForm.
+					ImageMorph new newForm: gridContainer imageForm}
 ]
 
 { #category : #building }

--- a/packages/Sandblocks-Babylonian/SBLiveView.class.st
+++ b/packages/Sandblocks-Babylonian/SBLiveView.class.st
@@ -23,10 +23,9 @@ SBLiveView >> buildBrodcaster [
 		addAllMorphsBack: {
 			self containerRow listDirection: #topToBottom;
 				addAllMorphsBack: {
-					SBOwnTextMorph new contents: 'Event Broadcaster'.
-					SBOwnTextMorph new contents: 'Interact to send events'.
-					broadcaster := SBInputBroadcaster new}.
-		LineMorph from: 0@0 to: 0@50 color: Color black width: 2}).
+					TextMorph new contents: 'Event Broadcaster'.
+					TextMorph new contents: 'Interact with to send events to all others'.
+					broadcaster := SBInputBroadcaster new}}).
 
 ]
 
@@ -41,8 +40,7 @@ SBLiveView >> buildPreviewFor: aPermutation [
 				 addAllMorphsBack: { 
 					SBPermutationLabel newDisplaying: aPermutation.
 					self newPermutationButtonRowFor: aPermutation showing: preview.
-					preview}.
-		LineMorph from: 0@0 to: 0@50 color: Color black width: 2}).
+					preview}}).
 ]
 
 { #category : #building }
@@ -66,7 +64,7 @@ SBLiveView >> buildSetUpRow [
 { #category : #building }
 SBLiveView >> buttons [
 
-	^ super buttons, {self resolveButton}
+	^ super buttons, {self rebuildButton}
 ]
 
 { #category : #actions }
@@ -100,7 +98,7 @@ SBLiveView >> initialize [
 
 	super initialize.
 	
-	self name: 'Live View'.
+	self name: 'Playground'.
 	self buildSetUpRow.
 	
 	
@@ -115,9 +113,9 @@ SBLiveView >> listeners [
 { #category : #building }
 SBLiveView >> newPermutationButtonRowFor: aPermutation showing: aPreview [
 
-	^ SBRow new
-		changeTableLayout;
-		cellGap: 8 * self scalingFactor;
+	^ self containerRow
+		layoutInset: 0;
+		cellInset: 0;
 		addAllMorphsBack: {
 			SBButton newApplyPermutationFor: aPermutation. 
 			self rebuildButtonIn: aPreview applying: aPermutation. 
@@ -205,6 +203,12 @@ SBLiveView >> setUpMorph [
 	^ (self block submorphNamed: 'setup') lastSubmorph 
 ]
 
+{ #category : #copying }
+SBLiveView >> snapshot [
+
+	^ {ImageMorph new newForm: gridContainer imageForm}
+]
+
 { #category : #building }
 SBLiveView >> synchronizeButtonIn: aContainer [
 
@@ -246,5 +250,5 @@ SBLiveView >> visualize [
 	self buildAllPossibleResults.
 	
 	broadcaster extent: self listeners last extent. 
-	self updateContainerWidth.	
+	self concludeContainerWidth.	
 ]

--- a/packages/Sandblocks-Babylonian/SBMultiverse.class.st
+++ b/packages/Sandblocks-Babylonian/SBMultiverse.class.st
@@ -110,7 +110,8 @@ SBMultiverse >> asyncKaboom [
 SBMultiverse >> cleanUp [
 	
 	watches do: #resumeGraphicalUpdates.
-	(watches select: [:anOpenWatch | anOpenWatch containingArtefact isNil]) copy do: #delete
+	(watches select: [:anOpenWatch | anOpenWatch containingArtefact isNil]) copy do: #delete.
+	watches select: #isInEditor thenDo: [:aWatch | aWatch exampleToDisplay values do: #updateDisplay].
 ]
 
 { #category : #collecting }
@@ -123,6 +124,20 @@ SBMultiverse >> findExistingOrConvertToBlocks: aCollectionOfCompiledMethods [
 				ifClosed: [aCompiledMethod asSandblock]]
 ]
 
+{ #category : #collecting }
+SBMultiverse >> findExistingOrConvertToBlocksMaintainingWatches: aCollectionOfCompiledMethods [ 
+
+	^ aCollectionOfCompiledMethods 
+		collect: [:aCompiledMethod | | sandBlock |
+			sandBlock := aCompiledMethod asSandblock.
+			sandBlock setProperty: #originals toValue: WeakOrderedCollection new.
+			self sandblockEditor blockFor: aCompiledMethod withInterfaces: #(#isMethod) 
+				ifOpen: [:existingMethodBlock |
+					(sandBlock valueOfProperty: #originals) addAll: existingMethodBlock containedExampleWatches.
+					sandBlock] 
+				ifClosed: [sandBlock]]
+]
+
 { #category : #'initialize-release' }
 SBMultiverse >> gatherElements [
 
@@ -131,7 +146,7 @@ SBMultiverse >> gatherElements [
 	have consistency between changes."
 	allMethodBlocksContainingVariants := self findExistingOrConvertToBlocks: self allCompiledMethodsContainingVariants.
 	
-	allMethodBlocksContainingWatches := self allCompiledMethodsContainingExampleWatches collect: #asSandblock.
+	allMethodBlocksContainingWatches := self findExistingOrConvertToBlocksMaintainingWatches: self allCompiledMethodsContainingExampleWatches.
 	
 	universes := OrderedCollection new.
 	activeExamples := self allActiveExamples.
@@ -139,9 +154,12 @@ SBMultiverse >> gatherElements [
 	variants := (allMethodBlocksContainingVariants collect: #containedVariants) flatten.
 	variants := variants select: #isActive.
 	
-	watches := (self allMethodBlocksContainingWatches collect: #containedExampleWatches) flatten.
-	watches do: [:aWatch | activeExamples do: [:anExample | aWatch exampleStarting: anExample].
-							 aWatch hide. aWatch extent: 1@1].
+	watches := (allMethodBlocksContainingWatches collect: [:aMethodBlock | | copies |
+		copies := aMethodBlock containedExampleWatches.
+		(aMethodBlock valueOfProperty: #originals) withIndexDo: [:original :i |  (copies at: i) copySelectedDisplayIndicesFrom: original].
+		copies ]) flatten.
+	watches do: [:aWatch | activeExamples do: [:anExample | aWatch exampleStarting: anExample]].
+	watches reject: #isInEditor thenDo: [:aWatch | aWatch hide. aWatch extent: 1@1]
 	
 ]
 

--- a/packages/Sandblocks-Babylonian/SBPermutationGridsView.class.st
+++ b/packages/Sandblocks-Babylonian/SBPermutationGridsView.class.st
@@ -32,12 +32,6 @@ SBPermutationGridsView >> currentClusterClass [
 		ifFalse: [SBPermutationCluster]
 ]
 
-{ #category : #updating }
-SBPermutationGridsView >> gridSize [
-
-	^ self multiverse universes size
-]
-
 { #category : #initialization }
 SBPermutationGridsView >> initialize [ 
 

--- a/packages/Sandblocks-Babylonian/SBPermutationGridsView.class.st
+++ b/packages/Sandblocks-Babylonian/SBPermutationGridsView.class.st
@@ -21,10 +21,7 @@ SBPermutationGridsView >> buildPermutationFor: aSBUniverse [
 					SBButton newApplyPermutationFor: aSBUniverse activePermutation. 
 					(self currentClusterClass 
 						newForSize: self selectedResizer
-						havingWatches: aSBUniverse watches)}.
-		LineMorph from: 0@0 to: 0@50 color: Color black width: 2}).
-		
-	self updateContainerWidth.
+						havingWatches: aSBUniverse watches)}})
 ]
 
 { #category : #building }
@@ -46,5 +43,5 @@ SBPermutationGridsView >> initialize [
 
 	super initialize.
 	
-	self name: 'Permutation Grid View'.
+	self name: 'Permutation Focused'.
 ]

--- a/packages/Sandblocks-Babylonian/SBPlainResultsView.class.st
+++ b/packages/Sandblocks-Babylonian/SBPlainResultsView.class.st
@@ -29,7 +29,7 @@ SBPlainResultsView >> initialize [
 ]
 
 { #category : #copying }
-SBPlainResultsView >> snapshot [
-
-	^ {}
+SBPlainResultsView >> wantsHistory [
+	
+	^ false
 ]

--- a/packages/Sandblocks-Babylonian/SBPlainResultsView.class.st
+++ b/packages/Sandblocks-Babylonian/SBPlainResultsView.class.st
@@ -25,5 +25,11 @@ SBPlainResultsView >> initialize [
 
 	super initialize.
 	
-	self name: 'Plain View'
+	self name: 'Watches'
+]
+
+{ #category : #copying }
+SBPlainResultsView >> snapshot [
+
+	^ {}
 ]

--- a/packages/Sandblocks-Babylonian/SBSwitchableResultsView.class.st
+++ b/packages/Sandblocks-Babylonian/SBSwitchableResultsView.class.st
@@ -62,7 +62,7 @@ SBSwitchableResultsView >> selectedResizer [
 { #category : #'as yet unclassified' }
 SBSwitchableResultsView >> snapshot [
 
-	^ {ImageMorph new newForm: gridContainer imageForm}
+	^ ImageMorph new newForm: gridContainer imageForm
 	
 ]
 

--- a/packages/Sandblocks-Babylonian/SBSwitchableResultsView.class.st
+++ b/packages/Sandblocks-Babylonian/SBSwitchableResultsView.class.st
@@ -59,6 +59,13 @@ SBSwitchableResultsView >> selectedResizer [
 	^ dimensionOptions object
 ]
 
+{ #category : #'as yet unclassified' }
+SBSwitchableResultsView >> snapshot [
+
+	^ {ImageMorph new newForm: gridContainer imageForm}
+	
+]
+
 { #category : #building }
 SBSwitchableResultsView >> toggleIcon [
 
@@ -93,5 +100,6 @@ SBSwitchableResultsView >> visualize [
 	self block addMorph: dimensionOptions.
 	self buildButtonRow.
 	
-	self buildAllPossibleResults 
+	self buildAllPossibleResults .
+	self concludeContainerWidth.
 ]

--- a/packages/Sandblocks-Babylonian/SBTrace.class.st
+++ b/packages/Sandblocks-Babylonian/SBTrace.class.st
@@ -60,8 +60,8 @@ SBTrace >> sortedWatchValuesFor: anExample givenWatches: aCollectionOfWatches [
 	| allValues |
 	allValues := SortedCollection sortBlock: [:a :b | a tracePosition <= b tracePosition].
 	aCollectionOfWatches do: [:aWatch | 
-		aWatch exampleToDisplay at: anExample 
-			ifPresent: [:aSBWatchView | allValues addAll: aSBWatchView display watchValues ]
+		aWatch exampleToValues at: anExample 
+			ifPresent: [:aCollectionOfWatchValues | allValues addAll: aCollectionOfWatchValues ]
 			ifAbsent: [{}]].
 	^ allValues
 ]

--- a/packages/Sandblocks-Babylonian/SBVariantsView.class.st
+++ b/packages/Sandblocks-Babylonian/SBVariantsView.class.st
@@ -1,13 +1,16 @@
 Class {
 	#name : #SBVariantsView,
 	#superclass : #SBExploriantsView,
+	#instVars : [
+		'contents'
+	],
 	#category : #'Sandblocks-Babylonian'
 }
 
 { #category : #building }
 SBVariantsView >> buildMethodSectionFor: aSBStMethod [
 	
-	self block addAllMorphsBack: {aSBStMethod methodDefinition.
+	contents addAllMorphsBack: {aSBStMethod methodDefinition.
 									self containerRow 
 										addAllMorphsBack: (aSBStMethod containedVariants collect: #asProxy).
 									LineMorph from: 0@0 to: 50@0 color: Color black width: 2}
@@ -16,7 +19,16 @@ SBVariantsView >> buildMethodSectionFor: aSBStMethod [
 { #category : #building }
 SBVariantsView >> buildNoVariantsText [
 	
-	self block addMorphBack: (SBOwnTextMorph new contents: 'No variants exist.')
+	contents addMorphBack: (SBOwnTextMorph new contents: 'No variants exist.')
+]
+
+{ #category : #actions }
+SBVariantsView >> clean [
+
+	super clean.
+	
+	contents submorphs copy do: #delete
+	
 ]
 
 { #category : #initialization }
@@ -24,13 +36,22 @@ SBVariantsView >> initialize [
 
 	super initialize.
 	
-	self name: 'Variant Manager'.
+	contents := self containerRow listDirection: #topToBottom.
+	
+	self name: 'Variants'.
+]
+
+{ #category : #copying }
+SBVariantsView >> snapshot [
+
+	^ {ImageMorph new newForm: contents imageForm}
 ]
 
 { #category : #actions }
 SBVariantsView >> visualize [ 
 
 	super visualize.
+	self block addMorphBack: contents.
 	self multiverse allMethodBlocksContainingVariants
 		ifNotEmptyDo: [:theMethods | theMethods do: [:aSBStMethod | self buildMethodSectionFor: aSBStMethod]] 
 		ifEmpty: [self buildNoVariantsText]

--- a/packages/Sandblocks-Babylonian/SBVariantsView.class.st
+++ b/packages/Sandblocks-Babylonian/SBVariantsView.class.st
@@ -44,7 +44,7 @@ SBVariantsView >> initialize [
 { #category : #copying }
 SBVariantsView >> snapshot [
 
-	^ {ImageMorph new newForm: contents imageForm}
+	^ ImageMorph new newForm: contents imageForm
 ]
 
 { #category : #actions }

--- a/packages/Sandblocks-Babylonian/SBVariantsView.class.st
+++ b/packages/Sandblocks-Babylonian/SBVariantsView.class.st
@@ -56,3 +56,9 @@ SBVariantsView >> visualize [
 		ifNotEmptyDo: [:theMethods | theMethods do: [:aSBStMethod | self buildMethodSectionFor: aSBStMethod]] 
 		ifEmpty: [self buildNoVariantsText]
 ]
+
+{ #category : #copying }
+SBVariantsView >> wantsHistory [ 
+
+	^ false
+]

--- a/packages/Sandblocks-Core/SBTabView.class.st
+++ b/packages/Sandblocks-Core/SBTabView.class.st
@@ -230,7 +230,7 @@ SBTabView >> initialize [
 	self
 		changeTableLayout;
 		listDirection: #topToBottom;
-		hResizing: #spaceFill;
+		hResizing: #shrinkWrap;
 		vResizing: #shrinkWrap.
 ]
 
@@ -395,7 +395,9 @@ SBTabView >> removeCurrentTab [
 { #category : #tabs }
 SBTabView >> setActive: aNamedBlock [
 
-	(self containingArtefact hasUnsavedChanges and: [self containingArtefact isMethod])
+	self containingArtefact isMethod ifFalse: [self basicSetActive: aNamedBlock. ^ self].
+	
+	self containingArtefact hasUnsavedChanges
 		ifTrue: [self basicSetActive: aNamedBlock] 
 		ifFalse: ["changing tabs is latest change"
 			self basicSetActive: aNamedBlock.

--- a/packages/Sandblocks-Watch/SBBarChart.class.st
+++ b/packages/Sandblocks-Watch/SBBarChart.class.st
@@ -40,7 +40,7 @@ SBBarChart >> newBarFor: aValue at: positionIndex [
 			color: self datapointDefaultColor;
 			width: self barWidth;
 			height: {(self scaleY scaledValueOf: aValue). 1} max;
-			bottom: self canvasHeight + self class heightMargin;
+			bottom: self targetHeight;
 			left: positionIndex * self spaceBetweenPoints;
 			setProperty: #chartValue toValue: (self scaleY scaledValueOf: aValue);
 			yourself);
@@ -66,4 +66,10 @@ SBBarChart >> newLineFrom: aDataPointMorph1 to: aDataPointMorph2 [
 		width: self lineWidth
 		
 	
+]
+
+{ #category : #'visualization - constants' }
+SBBarChart >> scaleYOffset [ 
+
+	^ 0 
 ]

--- a/packages/Sandblocks-Watch/SBExampleWatchView.class.st
+++ b/packages/Sandblocks-Watch/SBExampleWatchView.class.st
@@ -36,6 +36,14 @@ SBExampleWatchView >> reportValues: aCollectionOfWatchValues sized: aMorphResize
 	updateScheduled := true
 ]
 
+{ #category : #accessing }
+SBExampleWatchView >> savingCount [
+
+	"Any value < 1 will result in saving all reported values"
+	"Save all values"
+	^ -1
+]
+
 { #category : #display }
 SBExampleWatchView >> updateDisplay [
 

--- a/packages/Sandblocks-Watch/SBLineChart.class.st
+++ b/packages/Sandblocks-Watch/SBLineChart.class.st
@@ -42,7 +42,7 @@ SBLineChart >> datapointExtent [
 SBLineChart >> extent: aPoint [
 
 	super extent: aPoint.
-	self targetHeight: aPoint y.
+	self targetHeight: aPoint y- 6.
 	self scaleY range: (self scaleY range start to: aPoint y).
 	self visualize
 ]
@@ -91,13 +91,12 @@ SBLineChart >> newDatapointFor: aValue at: positionIndex [
 			color: self datapointDefaultColor;
 			borderWidth: 0;
 			left: positionIndex * self spaceBetweenPoints;
-			top: self targetHeight - (self scaleY scaledValueOf: aValue) - (self datapointExtent y / 2);
+			top: ((self targetHeight - (self scaleY scaledValueOf: aValue)) 
+				clampLow: 0 
+				high: (targetHeight - (self datapointExtent y / 2)));
 			setProperty: #chartValue toValue: (self scaleY scaledValueOf: aValue); 
 			yourself);
-		yourself
-	
-		
-	
+		yourself 
 ]
 
 { #category : #visualization }

--- a/packages/Sandblocks-Watch/SBLineChart.class.st
+++ b/packages/Sandblocks-Watch/SBLineChart.class.st
@@ -38,6 +38,15 @@ SBLineChart >> datapointExtent [
 	^ 4@4
 ]
 
+{ #category : #geometry }
+SBLineChart >> extent: aPoint [
+
+	super extent: aPoint.
+	self targetHeight: aPoint y.
+	self scaleY range: (self scaleY range start to: aPoint y).
+	self visualize
+]
+
 { #category : #visualization }
 SBLineChart >> lineColorFrom: aDataPoint1 to: aDataPoint2 [
 	
@@ -82,7 +91,7 @@ SBLineChart >> newDatapointFor: aValue at: positionIndex [
 			color: self datapointDefaultColor;
 			borderWidth: 0;
 			left: positionIndex * self spaceBetweenPoints;
-			top: self canvasHeight - (self scaleY scaledValueOf: aValue);
+			top: self targetHeight - (self scaleY scaledValueOf: aValue) - (self datapointExtent y / 2);
 			setProperty: #chartValue toValue: (self scaleY scaledValueOf: aValue); 
 			yourself);
 		yourself
@@ -136,10 +145,9 @@ SBLineChart >> newScaleLineHeight: height length: length [
 SBLineChart >> newScaleLinesOn: aMorph [
 	
 	| section |
-	section := self canvasHeight / (self numberScaleLines - 1).
-	
+	section := self targetHeight / (self numberScaleLines - 1).
 	^ (0 to: (self numberScaleLines - 1)) collect: [:i | 
-		self newScaleLineHeight: (section * i) + self scaleYOffset length: aMorph width]
+		self newScaleLineHeight: (section * i) length: aMorph width]
 		
 	
 ]
@@ -154,12 +162,6 @@ SBLineChart >> numberScaleLines [
 SBLineChart >> positiveGradientColor [
 	
 	^ Color green
-]
-
-{ #category : #'visualization - constants' }
-SBLineChart >> scaleYOffset [
-	
-	^ self datapointExtent y / 2
 ]
 
 { #category : #'visualization - constants' }

--- a/packages/Sandblocks-Watch/SBRectangleChart.class.st
+++ b/packages/Sandblocks-Watch/SBRectangleChart.class.st
@@ -13,7 +13,7 @@ SBRectangleChart class >> newWithValues: traceValues havingHeight: aNumber [
 	| biggestCoordinate absolutePoints coordinateSystemSize |
 	absolutePoints := traceValues collect: [:aPoint | aPoint abs].
 	biggestCoordinate := {absolutePoints max x. absolutePoints max y} max.
-	coordinateSystemSize := aNumber - self heightMargin.
+	coordinateSystemSize := aNumber.
 	^ self new
 		targetHeight: aNumber;
 		traceValues: traceValues;
@@ -55,7 +55,17 @@ SBRectangleChart >> borderStyleFor: scaledValues [
 { #category : #'visualization - constants' }
 SBRectangleChart >> coordinateSystemSize [
 	
-	^ self canvasHeight @ self canvasHeight
+	^ self targetHeight @ self targetHeight
+]
+
+{ #category : #geometry }
+SBRectangleChart >> extent: aPoint [
+
+	super extent: aPoint.
+	self targetHeight: aPoint y.
+	self scaleY range: (aPoint y / 2 negated to: aPoint y / 2).
+	self scaleX range: (aPoint y / 2 negated to: aPoint y / 2).
+	self visualize
 ]
 
 { #category : #visualization }
@@ -97,13 +107,12 @@ SBRectangleChart >> newRectangleFor: aValue at: positionIndex [
 	scaledWidth := self scaleX scaledValueOf: aValue x.
 	scaledHeight := self scaleY scaledValueOf: aValue y.
 	left := ((positionIndex - 0.5) * self spaceBetweenPoints) rounded.
-	
 	^ Morph new
-		extent: scaledWidth abs@scaledHeight abs;
+		extent: {scaledWidth abs. 1} max@{scaledHeight abs. 1} max;
 		color: (self rectangleColorForValue: aValue);
 		borderStyle: (self borderStyleFor: (scaledWidth @ scaledHeight));
-		left:  (scaledWidth / 2) + left;
-		top: (self coordinateSystemSize y / 2) - (scaledHeight abs / 2) - (scaledHeight/2) ;
+		left:  ({scaledWidth. 0} min )+ left;
+		top: (self coordinateSystemSize y / 2) - {scaledHeight. 0} max;
 		yourself
 	
 ]

--- a/packages/Sandblocks-Watch/SBVisualization.class.st
+++ b/packages/Sandblocks-Watch/SBVisualization.class.st
@@ -29,13 +29,7 @@ Class {
 { #category : #constants }
 SBVisualization class >> defaultHeight [
 	
-	^ 100 sbScaled 
-]
-
-{ #category : #constants }
-SBVisualization class >> heightMargin [ 
-
-	^ 5 sbScaled 
+	^ 100 
 ]
 
 { #category : #constants }
@@ -94,21 +88,6 @@ SBVisualization >> axisYNotation [
 	^ SBAxisNotation newFromScale: self scaleY ticking: 5 
 ]
 
-{ #category : #'visualization - constants' }
-SBVisualization >> canvasHeight [
-	
-	^ self targetHeight - self class heightMargin
-]
-
-{ #category : #geometry }
-SBVisualization >> extent: aPoint [
-
-	super extent: aPoint.
-	self targetHeight: aPoint y.
-	self scaleY range: (0 to: aPoint y).
-	self visualize
-]
-
 { #category : #initialization }
 SBVisualization >> initialize [ 
 
@@ -142,7 +121,7 @@ SBVisualization >> newBackground [
 
 	^ Morph new
 		color: self drawnColor;
-		width: (self traceValues size + 2 "to have some margin") * self spaceBetweenPoints;
+		width: self traceValues size * self spaceBetweenPoints;
 		height: self targetHeight;
 		borderWidth: 0;
 		yourself

--- a/packages/Sandblocks-Watch/SBWatchView.class.st
+++ b/packages/Sandblocks-Watch/SBWatchView.class.st
@@ -289,6 +289,7 @@ SBWatchView >> resetOnlyValues [
 
 	count contents: '0'.
 	watchValues := LinkedList new.
+	
 ]
 
 { #category : #actions }

--- a/packages/Sandblocks-Watch/SBWatchView.class.st
+++ b/packages/Sandblocks-Watch/SBWatchView.class.st
@@ -357,7 +357,7 @@ SBWatchView >> scroller [
 { #category : #display }
 SBWatchView >> selectedDisplay [
 
-	^ (self displayOptionsCache atWrap: selectedDisplayIndex) second
+	^ (self displayOptionsCache atWrap: selectedDisplayIndex) second lastSubmorph
 ]
 
 { #category : #accessing }

--- a/packages/Sandblocks-Watch/SBWatchView.class.st
+++ b/packages/Sandblocks-Watch/SBWatchView.class.st
@@ -6,29 +6,49 @@ Class {
 	#superclass : #SBBlock,
 	#instVars : [
 		'watchValues',
-		'numSavedValues',
-		'dark',
 		'count',
-		'clear',
+		'shouldUpdateDisplay',
+		'selectedDisplayIndex',
 		'fallbackResizer',
-		'updateScheduled',
-		'shouldUpdateDisplay'
+		'clear',
+		'updateScheduled'
 	],
 	#category : #'Sandblocks-Watch'
 }
 
-{ #category : #'as yet unclassified' }
-SBWatchView class >> saving: anInteger [
-	"Any value < 1 will result in saving all reported values"
-	
-	^ self new numSavedValues: anInteger
-]
-
 { #category : #accessing }
 SBWatchView >> addValue: aWatchValue sized: aSBMorphResizer [
 
-	(watchValues size >= numSavedValues and: [numSavedValues > 0]) ifTrue: [watchValues removeFirst].
+	(watchValues size >= self savingCount and: [self savingCount > 0]) ifTrue: [watchValues removeFirst].
 	^ watchValues addLast: (aWatchValue morphResizer: aSBMorphResizer)
+]
+
+{ #category : #display }
+SBWatchView >> buildCustomDisplayWith: aCollectionOfWatchValues [
+
+	| options |
+	options := Array streamContents: [:stream | 
+		(aCollectionOfWatchValues collect: #watchedValue) 
+			allConversionsFor: SBInterfaces topLevel do: [:pair | stream nextPut: pair]]. 
+	^ self watchValuesContainer 
+		addMorphBack: (self fallbackResizer applyOn: ((options atWrap: selectedDisplayIndex) second))
+]
+
+{ #category : #display }
+SBWatchView >> buildDefaultDisplayWith: aCollectionOfWatchValues [
+
+	^ self watchValuesContainer addAllMorphsBack: (aCollectionOfWatchValues collect: #asValueMorph)
+]
+
+{ #category : #display }
+SBWatchView >> buildDisplayOptions [
+
+	| options |
+	options := Array streamContents: [:stream | 
+		self values allConversionsFor: SBInterfaces topLevel do: [:pair | stream nextPut: pair]]. 
+	options := options do: [:aPair | aPair at: 2 put: (self watchValuesContainer addMorphBack: (self fallbackResizer applyOn: aPair second))].
+	options := options, {{'default'. self buildDefaultDisplayWith: watchValues}}.
+	^ options
 ]
 
 { #category : #'insert/delete' }
@@ -43,18 +63,19 @@ SBWatchView >> canDeleteChild: aBlock [
 	^ false
 ]
 
-{ #category : #display }
+{ #category : #actions }
 SBWatchView >> changeDisplay [
 	<action>
 
 	| index options |
-	options := Array streamContents: [:stream | 
-		self values allConversionsFor: SBInterfaces topLevel do: [:pair | stream nextPut: pair]]. 
-	options := options do: [:aPair | aPair at: 2 put: (self watchValuesContainer addMorphBack: (self fallbackResizer applyOn: aPair second))].
-	options := options, {{'default'. self watchValuesContainer addAllMorphsBack: (watchValues collect: #asValueMorph)}}.
+	options := self buildDisplayOptions. 
 	index := UIManager default chooseFrom: (options collect: #first).
 	index = 0 ifTrue: [^ self].
 	
+	(options at: index) first = 'default' 
+		ifTrue: [selectedDisplayIndex := 0]
+		ifFalse: [selectedDisplayIndex := index].
+		
 	self displayOnScrollPane: (options at: index) second.
 ]
 
@@ -131,8 +152,9 @@ SBWatchView >> displayOnScrollPane: aMorph [
 SBWatchView >> displayWatchValues [
 
 	| valuesMorph |
-	valuesMorph := self watchValuesContainer.
-	valuesMorph addAllMorphsBack: (watchValues collect: #asValueMorph).
+	valuesMorph := self isDisplayingWatchValues
+		ifTrue: [self buildDefaultDisplayWith: watchValues]  
+		ifFalse: [self buildCustomDisplayWith: watchValues].
 	"Will sometimes not update size otherwise when rushing through runs"
 	valuesMorph doLayoutSafely.
 	self displayOnScrollPane: valuesMorph.
@@ -191,9 +213,8 @@ SBWatchView >> initialize [
 
 	super initialize.
 	
-	dark := true.
+	selectedDisplayIndex := 0.
 	updateScheduled := false.
-	numSavedValues := 1.
 	watchValues := LinkedList new.
 	fallbackResizer := SBMorphResizer newSmall.
 	shouldUpdateDisplay := true.
@@ -218,6 +239,12 @@ SBWatchView >> initialize [
 ]
 
 { #category : #accessing }
+SBWatchView >> isDisplayingWatchValues [
+
+	^ selectedDisplayIndex = 0
+]
+
+{ #category : #accessing }
 SBWatchView >> lastValue [
 
 	^ watchValues last watchedValue
@@ -235,13 +262,6 @@ SBWatchView >> layoutCommands [
 SBWatchView >> maxWidth [
 
 	^ 350
-]
-
-{ #category : #accessing }
-SBWatchView >> numSavedValues: anInteger [
-	"Private"
-
-	numSavedValues := anInteger
 ]
 
 { #category : #'object interface' }
@@ -306,6 +326,14 @@ SBWatchView >> resizeThrough: aMorphResizer [
 	self fallbackResizer: aMorphResizer.
 ]
 
+{ #category : #accessing }
+SBWatchView >> savingCount [
+
+	"Any value < 1 will result in saving all reported values"
+	"Only save the last recent one"
+	^ 1
+]
+
 { #category : #layout }
 SBWatchView >> scrollBarHeight [
 
@@ -366,7 +394,6 @@ SBWatchView >> updateDisplay [
 { #category : #accessing }
 SBWatchView >> values [
 
-	watchValues ifEmpty: [^{}].
 	^ watchValues collect: [:value | value watchedValue]
 ]
 

--- a/packages/Sandblocks-Watch/SBWatchView.class.st
+++ b/packages/Sandblocks-Watch/SBWatchView.class.st
@@ -9,6 +9,7 @@ Class {
 		'count',
 		'shouldUpdateDisplay',
 		'selectedDisplayIndex',
+		'displayOptionsCache',
 		'fallbackResizer',
 		'clear',
 		'updateScheduled'
@@ -24,20 +25,16 @@ SBWatchView >> addValue: aWatchValue sized: aSBMorphResizer [
 ]
 
 { #category : #display }
-SBWatchView >> buildCustomDisplayWith: aCollectionOfWatchValues [
+SBWatchView >> buildCustomDisplay [
 
-	| options |
-	options := Array streamContents: [:stream | 
-		(aCollectionOfWatchValues collect: #watchedValue) 
-			allConversionsFor: SBInterfaces topLevel do: [:pair | stream nextPut: pair]]. 
 	^ self watchValuesContainer 
-		addMorphBack: (self fallbackResizer applyOn: ((options atWrap: selectedDisplayIndex) second))
+		addMorphBack: (self displayOptionsCache at: selectedDisplayIndex) second
 ]
 
 { #category : #display }
-SBWatchView >> buildDefaultDisplayWith: aCollectionOfWatchValues [
+SBWatchView >> buildDefaultDisplay [
 
-	^ self watchValuesContainer addAllMorphsBack: (aCollectionOfWatchValues collect: #asValueMorph)
+	^ self watchValuesContainer addAllMorphsBack: (watchValues collect: #asValueMorph)
 ]
 
 { #category : #display }
@@ -47,7 +44,7 @@ SBWatchView >> buildDisplayOptions [
 	options := Array streamContents: [:stream | 
 		self values allConversionsFor: SBInterfaces topLevel do: [:pair | stream nextPut: pair]]. 
 	options := options do: [:aPair | aPair at: 2 put: (self watchValuesContainer addMorphBack: (self fallbackResizer applyOn: aPair second))].
-	options := options, {{'default'. self buildDefaultDisplayWith: watchValues}}.
+	options := options, {{'default'. self buildDefaultDisplay}}.
 	^ options
 ]
 
@@ -67,16 +64,15 @@ SBWatchView >> canDeleteChild: aBlock [
 SBWatchView >> changeDisplay [
 	<action>
 
-	| index options |
-	options := self buildDisplayOptions. 
-	index := UIManager default chooseFrom: (options collect: #first).
+	| index |
+	index := UIManager default chooseFrom: (self displayOptionsCache collect: #first).
 	index = 0 ifTrue: [^ self].
 	
-	(options at: index) first = 'default' 
+	(displayOptionsCache at: index) first = 'default' 
 		ifTrue: [selectedDisplayIndex := 0]
 		ifFalse: [selectedDisplayIndex := index].
 		
-	self displayOnScrollPane: (options at: index) second.
+	self displayOnScrollPane: (displayOptionsCache at: index) second.
 ]
 
 { #category : #actions }
@@ -148,13 +144,19 @@ SBWatchView >> displayOnScrollPane: aMorph [
 		ifFalse: [self maxWidth])
 ]
 
+{ #category : #accessing }
+SBWatchView >> displayOptionsCache [
+
+	^ displayOptionsCache ifNil: [displayOptionsCache := self buildDisplayOptions]
+]
+
 { #category : #display }
 SBWatchView >> displayWatchValues [
 
 	| valuesMorph |
 	valuesMorph := self isDisplayingWatchValues
-		ifTrue: [self buildDefaultDisplayWith: watchValues]  
-		ifFalse: [self buildCustomDisplayWith: watchValues].
+		ifTrue: [self buildDefaultDisplay]  
+		ifFalse: [self buildCustomDisplay].
 	"Will sometimes not update size otherwise when rushing through runs"
 	valuesMorph doLayoutSafely.
 	self displayOnScrollPane: valuesMorph.
@@ -352,6 +354,25 @@ SBWatchView >> scroller [
 	^ self scrollPane scroller
 ]
 
+{ #category : #display }
+SBWatchView >> selectedDisplay [
+
+	^ (self displayOptionsCache atWrap: selectedDisplayIndex) second
+]
+
+{ #category : #accessing }
+SBWatchView >> selectedDisplayIndex [
+
+	^ selectedDisplayIndex
+]
+
+{ #category : #accessing }
+SBWatchView >> selectedDisplayIndex: aNumber [
+	
+	"Private, no side effects! Call updateDisplay if an update is desired"
+	selectedDisplayIndex := aNumber
+]
+
 { #category : #accessing }
 SBWatchView >> shouldUpdateDisplay [
 
@@ -375,6 +396,13 @@ SBWatchView >> storeAsExample [
 	self sandblockEditor open: class >> name asSymbol
 ]
 
+{ #category : #accessing }
+SBWatchView >> updateCache [
+
+	self isDisplayingWatchValues ifTrue: [^ self].
+	displayOptionsCache := self buildDisplayOptions
+]
+
 { #category : #display }
 SBWatchView >> updateDisplay [
 
@@ -388,6 +416,7 @@ SBWatchView >> updateDisplay [
 			disableLayout: false;
 			visible: true].
 		
+	self updateCache.	
 	self displayWatchValues
 ]
 


### PR DESCRIPTION
Adds a history tab to exploriants which takes pictures of the views and gathers them in a tab view for a moment of time when a multiverse is generated
![image](https://github.com/hpi-swa/sandblocks/assets/33000454/645bea54-577d-4311-8caf-4ab3cfd4c2ca)

For a more compact view, changes from a square-grid-layout to filling in as much space horizontally as the open editor allows, which is likely to be similiar to the users' displays. Some margins and insets have been reduced too. 

Another big change is the visualization of watch value collections in exploriants. Normally, even with a line chart as a display chosen, exploriants would cramp the serialized values in a grid, which can get ugly for smaller sizes.
![image](https://github.com/hpi-swa/sandblocks/assets/33000454/c723621b-3aa2-4af7-91af-7ec1e3db3b54)
Now, the displays chosen are taken over in the grid view, still presenting a challenge for smaller sizes, but good visual cues when enlarged and compared to just text
![image](https://github.com/hpi-swa/sandblocks/assets/33000454/91ffd121-5df9-4b24-a366-89f15cc4a947)
![image](https://github.com/hpi-swa/sandblocks/assets/33000454/9ea03eb0-2e20-47df-a93f-a97ee888fc54)


