### PR TITLE
SBExploriants Refactorings

### DIFF
--- a/packages/Sandblocks-Babylonian/Morph.extension.st
+++ b/packages/Sandblocks-Babylonian/Morph.extension.st
@@ -13,6 +13,12 @@ Morph class >> exampleObject [
 ]
 
 { #category : #'*Sandblocks-Babylonian' }
+Morph >> isVariantProxy [
+
+	^ false
+]
+
+{ #category : #'*Sandblocks-Babylonian' }
 Morph >> listensToPermutations [ 
 
 	^ false

--- a/packages/Sandblocks-Babylonian/SBCorrelationView.class.st
+++ b/packages/Sandblocks-Babylonian/SBCorrelationView.class.st
@@ -29,7 +29,7 @@ SBCorrelationView >> buildForExample: anExample watching: aWatch [
 			self containerRow listDirection: #topToBottom;
 				addAllMorphsBack: { 
 					SBOwnTextMorph new contents: (
-						'{1}{2}' format: {"anExample label" ''.
+						'{1}{2}' format: {anExample label.
 											 (aWatch cleanedExpression sourceString withoutLineEndings)}).
 					self containerRow 
 						listDirection: #topToBottom;
@@ -113,7 +113,7 @@ SBCorrelationView >> changeVariants [
 SBCorrelationView >> collectAllPermutationsOfSelectedVariants [
 	
 	| allPermutations |
-	selectedVariants ifEmpty: [^ {SBNilPermutation new referencedVariants: {}} asSet].
+	selectedVariants ifEmpty: [^ {SBPermutation singularity} asSet].
 	allPermutations := Set new.
 	groupedUniverses first do: [:aUniverseContainingSelected | | base |
 		base := SBPermutation new referencedVariants: selectedVariants.

--- a/packages/Sandblocks-Babylonian/SBCorrelationView.class.st
+++ b/packages/Sandblocks-Babylonian/SBCorrelationView.class.st
@@ -29,7 +29,7 @@ SBCorrelationView >> buildForExample: anExample watching: aWatch [
 			self containerRow listDirection: #topToBottom;
 				addAllMorphsBack: { 
 					SBOwnTextMorph new contents: (
-						'{1}{2}' format: {anExample label.
+						'{1} {2}' format: {anExample label.
 											 (aWatch cleanedExpression sourceString withoutLineEndings)}).
 					self containerRow 
 						listDirection: #topToBottom;

--- a/packages/Sandblocks-Babylonian/SBExampleWatch.class.st
+++ b/packages/Sandblocks-Babylonian/SBExampleWatch.class.st
@@ -82,7 +82,6 @@ SBExampleWatch class >> report: aValue for: aSymbol modifying: aBlock [
 	example := SBExecutionEnvironment value ifNil: [^ aValue].
 	watchers := self registry select: [:watcher | watcher notNil 
 		and: [watcher identifier = aSymbol]
-		and: [watcher ignoreReports not]
 		and: [watcher isActive]].
 	watchers do: [:watcher | watcher reportValue: aValue asSBWatchValue for: example].
 	
@@ -248,7 +247,6 @@ SBExampleWatch >> exampleFinished: anExample [
 SBExampleWatch >> exampleStarting: anExample [
 
 	exampleToValues at: anExample put: OrderedCollection new.
-	self ignoreReports: false. 
 
 	(exampleToDisplay at: anExample ifAbsentPut: [self buildDefaultDisplayFor: anExample])
 		exampleStarting: anExample;
@@ -324,18 +322,6 @@ SBExampleWatch >> identifier: aSymbol [
 
 	identifier := aSymbol.
 	self world ifNotNil: [self class registerWatch: self]
-]
-
-{ #category : #accessing }
-SBExampleWatch >> ignoreReports [
-
-	^ ignoreReports
-]
-
-{ #category : #accessing }
-SBExampleWatch >> ignoreReports: aBoolean [
-
-	ignoreReports := aBoolean
 ]
 
 { #category : #initialization }

--- a/packages/Sandblocks-Babylonian/SBExploriants.class.st
+++ b/packages/Sandblocks-Babylonian/SBExploriants.class.st
@@ -93,6 +93,13 @@ SBExploriants >> buttonClass [
 SBExploriants >> cacheType: aClass for: aBlock [
 ]
 
+{ #category : #actions }
+SBExploriants >> changeIndexOf: aVariantId to: aNewIndex [
+
+	namedBlocks detect: #isVariantsView
+			ifFound: [:variantsView | variantsView changeIndexOf: aVariantId to: aNewIndex]
+]
+
 { #category : #testing }
 SBExploriants >> evaluationContext [
 
@@ -219,6 +226,12 @@ SBExploriants >> updateInBackgroundOnTimeoutRevertTo: theOldMultiverse [
 						  self namedBlocks do: [:aTab | aTab multiverse: theOldMultiverse]]. 
 		updateProcess := nil. updateProcessRunning := false.
 	] forkAt: Processor userBackgroundPriority.
+]
+
+{ #category : #actions }
+SBExploriants >> variantsView [
+
+	^ namedBlocks detect: #isVariantsView
 ]
 
 { #category : #actions }

--- a/packages/Sandblocks-Babylonian/SBExploriants.class.st
+++ b/packages/Sandblocks-Babylonian/SBExploriants.class.st
@@ -113,6 +113,12 @@ SBExploriants >> evaluationReceiver [
 ]
 
 { #category : #accessing }
+SBExploriants >> generationTimeout [
+
+	^ 20 seconds
+]
+
+{ #category : #accessing }
 SBExploriants >> ignoreUpdate [
 
 	^ ignoreUpdate
@@ -221,7 +227,7 @@ SBExploriants >> updateInBackgroundOnTimeoutRevertTo: theOldMultiverse [
 		newMultiverse := SBMultiverse bigbangInEditorWithoutKaboom: self sandblockEditor.
 		self namedBlocks do: [:aTab | aTab multiverse: newMultiverse].
 		[newMultiverse kaboom] 
-			valueWithin: 20 seconds 
+			valueWithin: self generationTimeout
 			onTimeout: [newMultiverse cleanUp. 
 						  self namedBlocks do: [:aTab | aTab multiverse: theOldMultiverse]]. 
 		updateProcess := nil. updateProcessRunning := false.

--- a/packages/Sandblocks-Babylonian/SBExploriantsView.class.st
+++ b/packages/Sandblocks-Babylonian/SBExploriantsView.class.st
@@ -106,6 +106,12 @@ SBExploriantsView >> isOverview [
 ]
 
 { #category : #accessing }
+SBExploriantsView >> isVariantsView [
+
+	^ false
+]
+
+{ #category : #accessing }
 SBExploriantsView >> multiverse [
 
 	^ multiverse ifNil: [self multiverse: (SBMultiverse bigbangInEditor: SBEditor current)]

--- a/packages/Sandblocks-Babylonian/SBGridResultsView.class.st
+++ b/packages/Sandblocks-Babylonian/SBGridResultsView.class.st
@@ -54,5 +54,6 @@ SBGridResultsView >> newGridContainer [
 SBGridResultsView >> visualize [ 
 
 	super visualize.
-	self concludeContainerWidth
+	self concludeContainerWidth.
+
 ]

--- a/packages/Sandblocks-Babylonian/SBMultiverse.class.st
+++ b/packages/Sandblocks-Babylonian/SBMultiverse.class.st
@@ -119,7 +119,7 @@ SBMultiverse >> cleanUp [
 	(watches select: [:anOpenWatch | anOpenWatch containingArtefact isNil]) copy do: #delete.
 	watches select: #isInEditor thenDo: [:aWatch | aWatch exampleToDisplay values do: #updateDisplay].
 	allMethodBlocksContainingWatches do: [:aMethodBlock | 
-		(aMethodBlock valueOfProperty: #originals) do: [:aWatch| aWatch ignoreReports: true]].
+		(aMethodBlock valueOfProperty: #originals) do: [:aWatch| aWatch ignoreReports: false]].
 ]
 
 { #category : #collecting }

--- a/packages/Sandblocks-Babylonian/SBMultiverse.class.st
+++ b/packages/Sandblocks-Babylonian/SBMultiverse.class.st
@@ -116,10 +116,7 @@ SBMultiverse >> asyncKaboom [
 SBMultiverse >> cleanUp [
 	
 	watches do: #resumeGraphicalUpdates.
-	(watches select: [:anOpenWatch | anOpenWatch containingArtefact isNil]) copy do: #delete.
-	watches select: #isInEditor thenDo: [:aWatch | aWatch exampleToDisplay values do: #updateDisplay].
-	allMethodBlocksContainingWatches do: [:aMethodBlock | 
-		(aMethodBlock valueOfProperty: #originals) do: [:aWatch| aWatch ignoreReports: false]].
+	watches reject: #isInEditor thenDo: [:aWatch | SBExampleWatch unregisterWatch: aWatch].
 ]
 
 { #category : #collecting }
@@ -174,16 +171,9 @@ SBMultiverse >> gatherVariants [
 { #category : #'initialize-release' }
 SBMultiverse >> gatherWatches [
 	
-	allMethodBlocksContainingWatches := self findExistingOrConvertToBlocksMaintainingWatches: self allCompiledMethodsContainingExampleWatches.
+	allMethodBlocksContainingWatches := self findExistingOrConvertToBlocks: self allCompiledMethodsContainingExampleWatches.
 	
-	watches := (allMethodBlocksContainingWatches collect: [:aMethodBlock | | copies |
-		copies := aMethodBlock containedExampleWatches.
-		"Because the watches share the id, values would be reported to original too. Stop that"
-		(aMethodBlock valueOfProperty: #originals) do: [:aWatch| aWatch ignoreReports: true].
-		(aMethodBlock valueOfProperty: #originals) withIndexDo: [:original :i |  (copies at: i) copySelectedDisplayIndicesFrom: original].
-		copies ]) flatten.
-	watches do: [:aWatch | activeExamples do: [:anExample | aWatch exampleStarting: anExample]].
-	watches reject: #isInEditor thenDo: [:aWatch | aWatch hide. aWatch extent: 1@1]
+	watches := (allMethodBlocksContainingWatches collect: #containedExampleWatches) flatten.
 	
 ]
 
@@ -198,15 +188,16 @@ SBMultiverse >> initialize [
 { #category : #actions }
 SBMultiverse >> kaboom [
 	
-	| outOfWorldWatches permutations |
-	"Only open watches display values when examples are run. We want to show them too"
-	(outOfWorldWatches := watches reject: #isInEditor) do: [:aWatch | self sandblockEditor openMorph: aWatch].
-	permutations := (SBPermutation allPermutationsOf: variants).
+	| permutations |
 	watches do: #stopGraphicalUpdates.
+	watches reject: #isInEditor thenDo: [:aWatch | 
+		SBExampleWatch registerWatch: aWatch.
+		activeExamples do: [:anExample | aWatch exampleStarting: anExample]].
+	permutations := (SBPermutation allPermutationsOf: variants).
 	
 	"Running the active one last"
 	(permutations sorted: [:a :b | a activeScore  <= b activeScore ] ) do: [:aPermutation | 
-		self runPermutation: aPermutation copyingWatches: watches ].
+		self runPermutation: aPermutation copyingWatches: watches].
 	
 	"but stay consistent of the permutation sequences for alignment in clusters" 
 	"sorting this is cheaper than running a permutation twice just to reset to prior state"

--- a/packages/Sandblocks-Babylonian/SBMultiverse.class.st
+++ b/packages/Sandblocks-Babylonian/SBMultiverse.class.st
@@ -149,18 +149,32 @@ SBMultiverse >> findExistingOrConvertToBlocksMaintainingWatches: aCollectionOfCo
 { #category : #'initialize-release' }
 SBMultiverse >> gatherElements [
 
+	universes := OrderedCollection new.
+	activeExamples := self allActiveExamples.
+	
+	self gatherVariants.
+	
+	self gatherWatches
+	
+]
+
+{ #category : #'initialize-release' }
+SBMultiverse >> gatherVariants [
+
 	"We are looking for already opened methods so that we can assign the
 	variant there as the original in SBVariantProxy. That way, we immediately
 	have consistency between changes."
 	allMethodBlocksContainingVariants := self findExistingOrConvertToBlocks: self allCompiledMethodsContainingVariants.
 	
-	allMethodBlocksContainingWatches := self findExistingOrConvertToBlocksMaintainingWatches: self allCompiledMethodsContainingExampleWatches.
-	
-	universes := OrderedCollection new.
-	activeExamples := self allActiveExamples.
-	
 	variants := (allMethodBlocksContainingVariants collect: #containedVariants) flatten.
 	variants := variants select: #isActive.
+	
+]
+
+{ #category : #'initialize-release' }
+SBMultiverse >> gatherWatches [
+	
+	allMethodBlocksContainingWatches := self findExistingOrConvertToBlocksMaintainingWatches: self allCompiledMethodsContainingExampleWatches.
 	
 	watches := (allMethodBlocksContainingWatches collect: [:aMethodBlock | | copies |
 		copies := aMethodBlock containedExampleWatches.

--- a/packages/Sandblocks-Babylonian/SBPlainResultsView.class.st
+++ b/packages/Sandblocks-Babylonian/SBPlainResultsView.class.st
@@ -24,5 +24,5 @@ SBPlainResultsView >> initialize [
 
 	super initialize.
 	
-	self name: 'Watches'
+	self name: 'Probes'
 ]

--- a/packages/Sandblocks-Babylonian/SBSwitchableResultsView.class.st
+++ b/packages/Sandblocks-Babylonian/SBSwitchableResultsView.class.st
@@ -58,7 +58,7 @@ SBSwitchableResultsView >> toggleViewButton [
 
 	^ SBButton new
 		icon: self toggleIcon
-			label: 'Group By Watches <> In Execution Order'
+			label: 'Group By Probes <> In Execution Order'
 			do: [self toggleView];
 		cornerStyle: #squared
 ]

--- a/packages/Sandblocks-Babylonian/SBTrace.class.st
+++ b/packages/Sandblocks-Babylonian/SBTrace.class.st
@@ -60,8 +60,8 @@ SBTrace >> sortedWatchValuesFor: anExample givenWatches: aCollectionOfWatches [
 	| allValues |
 	allValues := SortedCollection sortBlock: [:a :b | a tracePosition <= b tracePosition].
 	aCollectionOfWatches do: [:aWatch | 
-		aWatch exampleToValues at: anExample 
-			ifPresent: [:aCollectionOfWatchValues | allValues addAll: aCollectionOfWatchValues ]
+		aWatch exampleToDisplay at: anExample 
+			ifPresent: [:aDisplay | allValues addAll: aDisplay value display watchValues ]
 			ifAbsent: [{}]].
 	^ allValues
 ]

--- a/packages/Sandblocks-Babylonian/SBVariantsView.class.st
+++ b/packages/Sandblocks-Babylonian/SBVariantsView.class.st
@@ -10,16 +10,25 @@ Class {
 { #category : #building }
 SBVariantsView >> buildMethodSectionFor: aSBStMethod [
 	
+	| newProxy |
+	newProxy := aSBStMethod containedVariants collect: #asProxy.
 	contents addAllMorphsBack: {aSBStMethod methodDefinition.
-									self containerRow 
-										addAllMorphsBack: (aSBStMethod containedVariants collect: #asProxy).
+									self containerRow addAllMorphsBack: newProxy.
 									LineMorph from: 0@0 to: 50@0 color: Color black width: 2}
 ]
 
 { #category : #building }
 SBVariantsView >> buildNoVariantsText [
 	
-	contents addMorphBack: (SBOwnTextMorph new contents: 'No variants exist.')
+	contents addMorphBack: (SBOwnTextMorph new contents: 'No variation points exist.')
+]
+
+{ #category : #actions }
+SBVariantsView >> changeIndexOf: aVariantId to: aNewIndex [
+
+	self proxies
+		detect: [:aProxy | aProxy original id = aVariantId] 
+		ifFound: [:theProxy | theProxy changeActiveIndexTo: aNewIndex ]
 ]
 
 { #category : #actions }
@@ -27,7 +36,7 @@ SBVariantsView >> clean [
 
 	super clean.
 	
-	contents submorphs copy do: #delete
+	contents submorphs copy do: #delete.
 	
 ]
 
@@ -38,7 +47,19 @@ SBVariantsView >> initialize [
 	
 	contents := self containerRow listDirection: #topToBottom.
 	
-	self name: 'Variants'.
+	self name: 'Variation Points'.
+]
+
+{ #category : #accessing }
+SBVariantsView >> isVariantsView [
+
+	^ true
+]
+
+{ #category : #actions }
+SBVariantsView >> proxies [
+
+	^ (contents allMorphs select: [:aMorph | aMorph isKindOf: SBVariantProxy])
 ]
 
 { #category : #copying }

--- a/packages/Sandblocks-Core/Collection.extension.st
+++ b/packages/Sandblocks-Core/Collection.extension.st
@@ -5,7 +5,7 @@ Collection >> asBarChart: converter [
 	<convert>
 	
 	converter
-		if: [self isString not and: [self isDictionary not and: [self allSatisfy: SBBarChart supportedInterface]]]
+		if: [self isString not and: [self allSatisfy: SBBarChart supportedInterface]]
 		do: [SBBarChart newWithValues: self]
 ]
 
@@ -23,7 +23,7 @@ Collection >> asLineChart: converter [
 	<convert>
 	
 	converter
-		if: [self isString not and: [self isDictionary not and: [self allSatisfy: SBLineChart supportedInterface]]]
+		if: [self isString not and: [self allSatisfy: SBLineChart supportedInterface]]
 		do: [SBLineChart newWithValues: self]
 ]
 

--- a/packages/Sandblocks-Core/Collection.extension.st
+++ b/packages/Sandblocks-Core/Collection.extension.st
@@ -5,7 +5,7 @@ Collection >> asBarChart: converter [
 	<convert>
 	
 	converter
-		if: [self isString not and: [self allSatisfy: SBBarChart supportedInterface]]
+		if: [self allSatisfy: SBBarChart supportedInterface]
 		do: [SBBarChart newWithValues: self]
 ]
 
@@ -23,7 +23,7 @@ Collection >> asLineChart: converter [
 	<convert>
 	
 	converter
-		if: [self isString not and: [self allSatisfy: SBLineChart supportedInterface]]
+		if: [self allSatisfy: SBLineChart supportedInterface]
 		do: [SBLineChart newWithValues: self]
 ]
 
@@ -32,7 +32,7 @@ Collection >> asRectangleChart: converter [
 	<convert>
 	
 	converter
-		if: [self isString not and: [self isDictionary not and: [self allSatisfy: SBRectangleChart supportedInterface]]]
+		if: [self allSatisfy: SBRectangleChart supportedInterface]
 		do: [SBRectangleChart newWithValues: self]
 ]
 

--- a/packages/Sandblocks-Core/SBTabView.class.st
+++ b/packages/Sandblocks-Core/SBTabView.class.st
@@ -174,6 +174,8 @@ SBTabView >> asTabButton: aNamedBlock [
 { #category : #tabs }
 SBTabView >> basicSetActive: aNamedBlock [
 
+	self sandblockEditor ifNil: [^ self activeIndex: (self namedBlocks indexOf: aNamedBlock ifAbsent: 1)].
+
 	self sandblockEditor do: 
 		(self switchCommandFor: (self namedBlocks indexOf: aNamedBlock ifAbsent: 1)).
 	

--- a/packages/Sandblocks-Smalltalk/SBStGrammarHandler.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStGrammarHandler.class.st
@@ -463,22 +463,6 @@ SBStGrammarHandler >> useThirdArgument [
 ]
 
 { #category : #'action helpers' }
-SBStGrammarHandler >> variantNameFor: aCollectionOfBlocks in: aParentBlock [
-	
-	aParentBlock sandblockEditor = aParentBlock ifTrue: [^ aCollectionOfBlocks printString].
-	
-	aParentBlock isTopLevel ifTrue: [^ aParentBlock printString].
-
-	aParentBlock isMessageSend ifTrue: [^ aCollectionOfBlocks first submorphBefore printString].
-	(aParentBlock isAssignment and: [aParentBlock receiver isVariant not]) ifTrue: [^ aParentBlock receiver sourceString, ' := '].
-	
-	aCollectionOfBlocks size = 1 ifTrue: [^ aCollectionOfBlocks first sourceString].
-	
-	^ '{1}' format: {(aCollectionOfBlocks collect: [:aBlock | aBlock sourceString]) 
-			fold: [:a :b | a, ', ', Character cr, b ]}
-]
-
-{ #category : #'action helpers' }
 SBStGrammarHandler >> variantNameFor: aCollectionOfBlocks in: aParentBlock preceedingBlock: aNeighbor [
 	
 	aParentBlock isMessageSend 

--- a/packages/Sandblocks-Smalltalk/SBVariant.class.st
+++ b/packages/Sandblocks-Smalltalk/SBVariant.class.st
@@ -181,11 +181,7 @@ SBVariant >> allPermutations: allPermutations currentPath: aPermutation [
 			ifEmpty: [allPermutations add: currentPath]
 			ifNotEmpty: [:childVariants | | permutations nestedPermutations | 
 				nestedPermutations := childVariants collect: [:child | child allPermutations: OrderedCollection new currentPath: currentPath].
-				permutations := nestedPermutations first. 
-				(2 to: topLevelVariants size) do: [:index | | nestedPermutation |
-					nestedPermutation := nestedPermutations at: index.
-					permutations := permutations gather: [:aNestedPermutation | 
-						nestedPermutation collect: [:aNestedNestedPermutation | SBPermutation newCombinedOf: aNestedPermutation and: aNestedNestedPermutation]]].
+				permutations := SBPermutation combineAllIn: nestedPermutations.
 				allPermutations addAll: permutations.
 				permutations ]]
 ]
@@ -261,6 +257,12 @@ SBVariant >> blockAt: anIndex [
 SBVariant >> color [
 
 	^ Color transparent
+]
+
+{ #category : #accessing }
+SBVariant >> hasParent [
+
+	^ self parentVariant isNil not
 ]
 
 { #category : #accessing }

--- a/packages/Sandblocks-Smalltalk/SBVariant.class.st
+++ b/packages/Sandblocks-Smalltalk/SBVariant.class.st
@@ -90,7 +90,7 @@ SBVariant class >> named: aString associations: aCollectionOfAssociations active
 	
 	requestor := thisContext sender receiver.
 	"The requesting object does not require dynamic update behavior in which it needs to know a certain alternative"
-	SBExploriants objectToPermutation at: (requestor := thisContext sender receiver) ifAbsent: [^ defaultBehavior value].
+	SBExploriants objectToPermutation at: requestor ifAbsent: [^ defaultBehavior value].
 	"The permutation is outdated and does not know this variant"
 	(requiredPermutation := SBExploriants objectToPermutation at: requestor) at: uuid ifAbsent: [^ defaultBehavior value].
 	"An outdated permutation in which an alternative with a higher index than current has been deleted"

--- a/packages/Sandblocks-Smalltalk/SBVariantProxy.class.st
+++ b/packages/Sandblocks-Smalltalk/SBVariantProxy.class.st
@@ -16,7 +16,6 @@ SBVariantProxy class >> for: aVariant [
 
 { #category : #callbacks }
 SBVariantProxy >> artefactChanged: anArtefact [
-
 	
 	anArtefact = self ifTrue: [self updateOriginalWithOwnValues ].
 		
@@ -34,6 +33,15 @@ SBVariantProxy >> artefactSaved: anArtefact [
 SBVariantProxy >> binding: aString for: block class: aClass ifPresent: aBlock [
 	
 	^ original binding: aString for: block class: aClass ifPresent: aBlock
+]
+
+{ #category : #accessing }
+SBVariantProxy >> changeActiveIndexTo: aNewIndex [
+
+	self firstSubmorph switchToAlternativeWithoutSaving: aNewIndex.
+	self updateOriginalWithOwnValues
+	
+	
 ]
 
 { #category : #accessing }

--- a/packages/Sandblocks-Smalltalk/SBVariantProxy.class.st
+++ b/packages/Sandblocks-Smalltalk/SBVariantProxy.class.st
@@ -14,6 +14,12 @@ SBVariantProxy class >> for: aVariant [
 	^ self new for: aVariant
 ]
 
+{ #category : #accessing }
+SBVariantProxy >> activeIndex [
+
+	^ original activeIndex
+]
+
 { #category : #callbacks }
 SBVariantProxy >> artefactChanged: anArtefact [
 	
@@ -60,6 +66,12 @@ SBVariantProxy >> for: aVariant [
 	self addMorphBack: original copyBlock.
 ]
 
+{ #category : #accessing }
+SBVariantProxy >> id [
+
+	^ original id
+]
+
 { #category : #initialization }
 SBVariantProxy >> initialize [
 
@@ -75,6 +87,12 @@ SBVariantProxy >> initialize [
 
 { #category : #testing }
 SBVariantProxy >> isArtefact [
+
+	^ true
+]
+
+{ #category : #testing }
+SBVariantProxy >> isVariantProxy [
 
 	^ true
 ]
@@ -106,12 +124,11 @@ SBVariantProxy >> updateOriginalWithOwnValues [
 
 	| variantThatNeedsChanging |
 	variantThatNeedsChanging := self containedMethod detectVariant: original.
-	
 	variantThatNeedsChanging ifNil: [^self delete].
 	
 	original replaceBy: (original := self firstSubmorph copyBlock).
-	original isVariant 
-		ifFalse: [
+	"If a double click on the widget occured and it replaced itself with code or text"
+	original isVariant ifFalse: [
 			self containedMethod save.
 			^ self delete].
 	

--- a/packages/Sandblocks-Utils/SBPermutation.class.st
+++ b/packages/Sandblocks-Utils/SBPermutation.class.st
@@ -14,19 +14,32 @@ Class {
 { #category : #utils }
 SBPermutation class >> allPermutationsOf: aCollectionOfVariants [
 
-	| permutations topLevelVariants nestedPermutations |
-	aCollectionOfVariants ifEmpty:[^{SBNilPermutation new referencedVariants: {}}].
-	topLevelVariants := aCollectionOfVariants select: [:aVariant | aVariant parentVariant isNil].
+	| topLevelVariants nestedPermutations |
+	aCollectionOfVariants ifEmpty:[^{SBPermutation singularity}].
+	topLevelVariants := aCollectionOfVariants reject: #hasParent.
 	nestedPermutations := topLevelVariants collect: #allPermutations.
-	permutations := nestedPermutations first.
 	
-	(2 to: topLevelVariants size) do: [:i | | nestedPermutation |
-		nestedPermutation := (nestedPermutations at: i).
-		permutations := permutations gather: [:aPermutation | 
-			nestedPermutation collect: [:aNestedPermutation | self newCombinedOf: aPermutation and: aNestedPermutation]]].
-	
-	^ permutations 
-		
+	^ SBPermutation combineAllIn: nestedPermutations.
+]
+
+{ #category : #utils }
+SBPermutation class >> combine: aPermutation withAll: aCollectionOfPermutations [
+ 
+	^ aCollectionOfPermutations collect: [:anotherPermutation | 
+			self newCombinedOf: aPermutation and: anotherPermutation]
+]
+
+{ #category : #utils }
+SBPermutation class >> combineAllIn: aCollectionOfNestedPermutations [ 
+
+	| combinedPermutations |
+	combinedPermutations := aCollectionOfNestedPermutations first. 
+	(2 to: aCollectionOfNestedPermutations size) do: [:index | | aCollectionOfPermutations |
+		aCollectionOfPermutations := aCollectionOfNestedPermutations at: index.
+		combinedPermutations := combinedPermutations gather: [:aPermutation | 
+			SBPermutation combine: aPermutation withAll: aCollectionOfPermutations]].
+			
+	^ combinedPermutations
 ]
 
 { #category : #utils }
@@ -40,6 +53,12 @@ SBPermutation class >> newCombinedOf: onePermutation and: anotherPermutation [
 	result addAll: anotherPermutation.
 	^ result
 	
+]
+
+{ #category : #utils }
+SBPermutation class >> singularity [ 
+
+	^ SBNilPermutation new referencedVariants: {}
 ]
 
 { #category : #accessing }
@@ -151,7 +170,7 @@ SBPermutation >> copyRemovingVariants: aCollectionOfVariants [
 	 | copy |
 	copy := self class new.
 	copy referencedVariants: (self referencedVariants reject: [:aVariant | aCollectionOfVariants includes: aVariant]).
-	copy referencedVariants ifEmpty: [^ SBNilPermutation new referencedVariants: {}]. 
+	copy referencedVariants ifEmpty: [^ SBPermutation singularity]. 
 	"copy := self veryDeepCopy.
 	copy referencedVariants: (copy referencedVariants difference: aCollectionOfVariants)."
 	

--- a/packages/Sandblocks-Utils/SBPermutation.class.st
+++ b/packages/Sandblocks-Utils/SBPermutation.class.st
@@ -52,15 +52,39 @@ SBPermutation >> activeScore [
 
 { #category : #actions }
 SBPermutation >> apply [
+	
+	self flag: #todo. "outdated references, jb" 
+	(self referencedVariants anySatisfy: [:aVariant | aVariant sandblockEditor isNil])
+		ifTrue: [ self applyWithOutdatedReferences ]
+		ifFalse: [ self applyOnOriginals ].
+	
+	
+]
 
+{ #category : #private }
+SBPermutation >> applyOnOriginals [
+	
 	self referencedVariants do: [:aVariant | aVariant switchToAlternativeWithoutSaving: (self at: aVariant id)].
 	SBExploriants uniqueInstance ignoreUpdate: true.
 	((self referencedVariants collect: #containingArtefact) asSet) do: [:aMethod | 
-		self referencedVariants first sandblockEditor save: aMethod tryFixing: false quick: false].
+		aMethod sandblockEditor save: aMethod tryFixing: false quick: false].
+	(self referencedVariants collect: #sandblockEditor) do: #sendNewPermutationNotification
 	
-	((Set newFrom: (referencedVariants collect: #sandblockEditor))
-		reject: #isNil)
-		do: #sendNewPermutationNotification
+	
+]
+
+{ #category : #private }
+SBPermutation >> applyWithOutdatedReferences [
+	
+	| newVariants |
+	self keys do: [:anId | SBExploriants uniqueInstance changeIndexOf: anId to: (self at: anId)].
+	newVariants := SBExploriants uniqueInstance variantsView proxies collect: #original.
+	self referencedVariants do: [:aVariant | 
+		newVariants detect: [:new | new id = aVariant id] 
+			ifFound: [:theVariant | aVariant becomeForward: theVariant]].
+	SBEditor current sendNewPermutationNotification
+	
+	
 ]
 
 { #category : #converting }

--- a/packages/Sandblocks-Watch/SBLineChart.class.st
+++ b/packages/Sandblocks-Watch/SBLineChart.class.st
@@ -35,7 +35,7 @@ SBLineChart >> datapointDefaultColor [
 { #category : #'visualization - constants' }
 SBLineChart >> datapointExtent [
 	
-	^ 2@2
+	^ 3@3 sbScaled 
 ]
 
 { #category : #geometry }
@@ -60,7 +60,7 @@ SBLineChart >> lineColorFrom: aDataPoint1 to: aDataPoint2 [
 { #category : #'visualization - constants' }
 SBLineChart >> lineWidth [
 	
-	^ 2
+	^ 2 sbScaled 
 ]
 
 { #category : #'visualization - constants' }
@@ -166,7 +166,7 @@ SBLineChart >> positiveGradientColor [
 { #category : #'visualization - constants' }
 SBLineChart >> spaceBetweenPoints [
 	
-	^ 6
+	^ 6 sbScaled
 ]
 
 { #category : #visualization }

--- a/packages/Sandblocks-Watch/SBWatchView.class.st
+++ b/packages/Sandblocks-Watch/SBWatchView.class.st
@@ -263,7 +263,7 @@ SBWatchView >> layoutCommands [
 { #category : #layout }
 SBWatchView >> maxWidth [
 
-	^ 350
+	^ 350 sbScaled 
 ]
 
 { #category : #'object interface' }
@@ -309,7 +309,7 @@ SBWatchView >> reportValues: aCollectionOfWatchValues sized: aMorphResizer [
 SBWatchView >> resetOnlyValues [
 	"Private"
 
-	count contents: '0'.
+	shouldUpdateDisplay ifTrue: [count contents: '0'].
 	watchValues := LinkedList new.
 	
 ]


### PR DESCRIPTION
-few size fixes (2 -> 2 sbScaled)
-rename watch -> probe
-delete ignoreReports in probes
-make permutation generation more readable
-bug fixing for applying oudated permutations
-remote variation point changing / bugfixing