### PR TITLE
Filter Exploriants History for individual widgets 

### DIFF
--- a/packages/Sandblocks-Babylonian/ImageMorph.extension.st
+++ b/packages/Sandblocks-Babylonian/ImageMorph.extension.st
@@ -8,3 +8,13 @@ ImageMorph >> applyResize: aPoint [
 	form := form applyResize: aPoint.
 	^ form asMorph
 ]
+
+{ #category : #'*Sandblocks-Babylonian' }
+ImageMorph >> layoutedTaggedCopy [
+
+	^ super layoutedTaggedCopy
+		image: self image;
+		yourself
+				
+		
+]

--- a/packages/Sandblocks-Babylonian/Morph.extension.st
+++ b/packages/Sandblocks-Babylonian/Morph.extension.st
@@ -7,14 +7,6 @@ Morph >> applyResize: aPoint [
 ]
 
 { #category : #'*Sandblocks-Babylonian' }
-Morph >> childrenFormCollection [
-	
-	^ (self isTextMorph or: [self isStringMorph])
-		ifTrue: [{}]
-		ifFalse: [{ImageMorph new newForm: self imageForm}]
-]
-
-{ #category : #'*Sandblocks-Babylonian' }
 Morph class >> exampleObject [
 
 	^ self new

--- a/packages/Sandblocks-Babylonian/Morph.extension.st
+++ b/packages/Sandblocks-Babylonian/Morph.extension.st
@@ -7,9 +7,38 @@ Morph >> applyResize: aPoint [
 ]
 
 { #category : #'*Sandblocks-Babylonian' }
+Morph >> childrenFormCollection [
+	
+	^ (self isTextMorph or: [self isStringMorph])
+		ifTrue: [{}]
+		ifFalse: [{ImageMorph new newForm: self imageForm}]
+]
+
+{ #category : #'*Sandblocks-Babylonian' }
 Morph class >> exampleObject [
 
 	^ self new
+]
+
+{ #category : #'*Sandblocks-Babylonian' }
+Morph >> hasBeenTagged [
+
+	^ self tag isNilTag not
+]
+
+{ #category : #'*Sandblocks-Babylonian' }
+Morph >> layoutedTaggedCopy [
+
+	^ self class new
+		extent: self extent;
+		color: self color;
+		layoutProperties: self layoutProperties;
+		layoutPolicy: self layoutPolicy;
+		borderStyle: self borderStyle;
+		tag: self tag;
+		yourself 
+				
+		
 ]
 
 { #category : #'*Sandblocks-Babylonian' }
@@ -19,11 +48,76 @@ Morph >> listensToPermutations [
 ]
 
 { #category : #'*Sandblocks-Babylonian' }
+Morph >> satisfiesTag: anotherSBTag [
+
+	^ self tag satisfiesTag: anotherSBTag
+]
+
+{ #category : #'*Sandblocks-Babylonian' }
 Morph >> sbWatchValueMorphFor: aSBWatchValue sized: aSBMorphResizer [
 
 	^ (SBWatchValue newContainerMorphFor: aSBWatchValue)  
 		addMorphBack: (aSBMorphResizer applyOn: self sbSnapshot asMorph);
 		yourself
+]
+
+{ #category : #'*Sandblocks-Babylonian' }
+Morph >> snapshot [
+
+	^ self snapshotSatisfying: {} 
+]
+
+{ #category : #'*Sandblocks-Babylonian' }
+Morph >> snapshotSatisfying: aCollectionOfTags [
+	
+	| emptyCopy |
+	"normal morph, doesn't even know tags!"
+	(self hasBeenTagged not and: [ self topLevelTaggedChildren isEmpty ])
+		ifTrue: [^ ImageMorph new newForm: self imageForm ]. 
+	
+	"there are some tags in this layout that we want to preserve"
+	emptyCopy := self layoutedTaggedCopy.
+	
+	"Not satisfying tag, filter out" 
+	(self hasBeenTagged and: [aCollectionOfTags anySatisfy: [:aTag | (self satisfiesTag: aTag) not ]])
+		ifTrue: [ ^ nil ]. 
+	
+	"When this is the last tag in the hierarchy, we can stop right here."
+	(self hasBeenTagged and: [self topLevelTaggedChildren isEmpty]) 
+		ifTrue: [ ^ (ImageMorph new newForm: self imageForm) tag: self tag].
+			
+	"Process and add tagged children."
+	^ emptyCopy addAllMorphsBack: ((self submorphs 
+											collect: [:aChild | aChild snapshotSatisfying: aCollectionOfTags])
+											reject: #isNil)
+	
+]
+
+{ #category : #'*Sandblocks-Babylonian' }
+Morph >> tag [
+
+	^ self valueOfProperty: #SBTag ifAbsentPut: [ SBNilTag new ]
+]
+
+{ #category : #'*Sandblocks-Babylonian' }
+Morph >> tag: aSBTag [
+	
+	self setProperty: #SBTag toValue: aSBTag 
+]
+
+{ #category : #'*Sandblocks-Babylonian' }
+Morph >> topLevelTaggedChildren [
+
+	| childrenToCheck foundTaggedChildren |
+	childrenToCheck := self submorphs asOrderedCollection.
+	foundTaggedChildren := OrderedCollection new.
+	[childrenToCheck isEmpty] whileFalse: [ | child |
+		child := childrenToCheck removeFirst. 
+		child hasBeenTagged
+			ifTrue: [foundTaggedChildren add: child]
+			ifFalse: [childrenToCheck addAll: child submorphs]].
+	^ foundTaggedChildren 
+	
 ]
 
 { #category : #'*Sandblocks-Babylonian' }

--- a/packages/Sandblocks-Babylonian/SBCluster.class.st
+++ b/packages/Sandblocks-Babylonian/SBCluster.class.st
@@ -189,7 +189,7 @@ SBCluster >> wrapInCell: aMorph flexVertically: aVBoolean flexHorizontally: aHBo
 	cell addMorph: (ImageMorph new 
 		newForm: (aMorph imageForm scaledIntoFormOfSize: targetExtent);
 		when: #clicked send: #triggerEvent: to: aMorph with: #clicked;
-		tag: aMorph tag)..
+		tag: aMorph tag).
 	cell on: #click send: #value to: [cell submorphs first triggerEvent: #clicked].
 	^ cell
 ]

--- a/packages/Sandblocks-Babylonian/SBCluster.class.st
+++ b/packages/Sandblocks-Babylonian/SBCluster.class.st
@@ -169,7 +169,7 @@ SBCluster >> wrapInCell: aMorph [
 { #category : #helper }
 SBCluster >> wrapInCell: aMorph flexVertically: aVBoolean flexHorizontally: aHBoolean [
 
-	| cell targetExtent|
+	| cell targetExtent |
 	cell := self newCellMorph.
 	
 	aVBoolean ifTrue: [cell vResizing: #shrinkWrap].
@@ -188,7 +188,8 @@ SBCluster >> wrapInCell: aMorph flexVertically: aVBoolean flexHorizontally: aHBo
 	self flag: #todo. "Another way besides turning into an image to keep interactions.-jb"
 	cell addMorph: (ImageMorph new 
 		newForm: (aMorph imageForm scaledIntoFormOfSize: targetExtent);
-		when: #clicked send: #triggerEvent: to: aMorph with: #clicked).
+		when: #clicked send: #triggerEvent: to: aMorph with: #clicked;
+		tag: aMorph tag)..
 	cell on: #click send: #value to: [cell submorphs first triggerEvent: #clicked].
 	^ cell
 ]

--- a/packages/Sandblocks-Babylonian/SBCorrelationCluster.class.st
+++ b/packages/Sandblocks-Babylonian/SBCorrelationCluster.class.st
@@ -55,10 +55,16 @@ SBCorrelationCluster >> buildDisplayMatrix [
 		rows: 2
 		columns: self correlatingUniverses size + 1.
 		
-	matrix atRow: 1 put: ({TextMorph new contents: self basePermutation asVariantString}, 
+	matrix atRow: 1 put: ({TextMorph new
+								tag: (SBTag newFromPermutation: self basePermutation); 
+								contents: self basePermutation asVariantString;
+								yourself}, 
 	(self extractedTopHeadingsFrom: self correlatingUniverses)).
 	
-	matrix at: 2 at: 1 put: (SBPermutationLabel newDisplaying: self basePermutation).
+	matrix at: 2 at: 1 put: ((SBPermutationLabel 
+								newDisplaying: self basePermutation)
+								tag: (SBTag newFromPermutation: self basePermutation);
+								yourself).
 
 	self extractRow withIndexDo: [:aCellMorph :column | matrix at: 2 at: column+1 put: aCellMorph].
 
@@ -105,19 +111,24 @@ SBCorrelationCluster >> displayedWatch: anSBExampleWatch [
 SBCorrelationCluster >> extractRow [
 
 	^ self correlatingUniverses 
-		collect: [:aUniverse | | display | 
-		display := ((aUniverse watches detect: [:aWatch | aWatch originalIdentifier = self displayedWatch identifier]) 
-					exampleToDisplay at: self displayedExample) value display.
-		self compressedMorphsForDisplay: display]
+		collect: [:aUniverse | | display watchMorph |
+		watchMorph :=  aUniverse watches detect: [:aWatch | aWatch originalIdentifier = self displayedWatch identifier].
+		display := (watchMorph exampleToDisplay at: self displayedExample) value display.
+		(self compressedMorphsForDisplay: display)
+			tag: (SBTag new
+				addFromExample: self displayedExample;
+				addFromWatch: self displayedWatch;
+				addFromPermutation: aUniverse activePermutation )]
 ]
 
 { #category : #building }
 SBCorrelationCluster >> extractedTopHeadingsFrom: aCollectionOfCorrelatingUniverses [
 
-	^ aCollectionOfCorrelatingUniverses collect: [:aCorrelatingUniverse |  
-		SBPartialPermutationLabel 
-			newDisplaying: (aCorrelatingUniverse activePermutation copyRemovingVariants: self basePermutation referencedVariants)
-			referingTo: aCorrelatingUniverse]
+	^ aCollectionOfCorrelatingUniverses collect: [:aCorrelatingUniverse | | partialPermutation |
+		partialPermutation :=  (aCorrelatingUniverse activePermutation copyRemovingVariants: self basePermutation referencedVariants).
+		(SBPartialPermutationLabel 
+			newDisplaying: partialPermutation
+			referingTo: aCorrelatingUniverse)]
 ]
 
 { #category : #visualisation }
@@ -131,6 +142,7 @@ SBCorrelationCluster >> newTopRowFrom: aCollectionOfPermutationLabels [
 		hResizing: #spaceFill;
 		addAllMorphsBack: (aCollectionOfPermutationLabels collect: [:aLabel | 
 			self newContainerMorph 
+				tag: (SBTag newFromPermutation: aLabel universe activePermutation);
 				addAllMorphsBack: {
 					(self 
 						wrapInCell: aLabel 

--- a/packages/Sandblocks-Babylonian/SBCorrelationView.class.st
+++ b/packages/Sandblocks-Babylonian/SBCorrelationView.class.st
@@ -28,14 +28,21 @@ SBCorrelationView >> buildAllPossibleResults [
 { #category : #building }
 SBCorrelationView >> buildForExample: anExample watching: aWatch [
 
-	gridContainer addMorphBack: (self containerRow cellPositioning: #center;
-		addAllMorphsBack: {
-			self containerRow listDirection: #topToBottom;
-				addAllMorphsBack: { 
-					SBOwnTextMorph new contents: (
-						'{1}, {2}' format: {anExample label.
-											 (aWatch cleanedExpression sourceString)}).
-					self buildGridsFor: anExample watching: aWatch} flatten})
+	gridContainer addMorphBack: (
+		self containerRow 
+			cellPositioning: #center;
+			tag: (SBTag new 
+					addFromExample: anExample;
+					addFromWatch: aWatch);
+			addAllMorphsBack: {
+				self containerRow 
+					listDirection: #topToBottom;
+					cellPositioning: #bottomRight;
+					addAllMorphsBack: { 
+						SBOwnTextMorph new contents: (
+							'{1}, {2}' format: {anExample label.
+												 (aWatch cleanedExpression sourceString)}).
+						self buildGridsFor: anExample watching: aWatch} flatten})
 ]
 
 { #category : #building }

--- a/packages/Sandblocks-Babylonian/SBCustomView.class.st
+++ b/packages/Sandblocks-Babylonian/SBCustomView.class.st
@@ -38,7 +38,7 @@ SBCustomView >> initialize [
 	self buildButtonRow.
 	
 	self block addMorphBack: viewOptions.
-	self block addMorphBack: self selectedView
+	self block addMorphBack: self selectedView block
 	
 ]
 

--- a/packages/Sandblocks-Babylonian/SBExample.class.st
+++ b/packages/Sandblocks-Babylonian/SBExample.class.st
@@ -136,10 +136,7 @@ SBExample >> assertionBlock [
 SBExample >> backtrack [
 	<action>
 	
-	SBExploriants uniqueInstance isInEditor 
-		ifTrue: [
-			self sandblockEditor openMorphInView: 
-				(SBExploriants uniqueInstance historyView backtrackForExample: self)] 
+	SBExploriants backtrack: #backtrackForExample: withArguments: {self}
 
 	
 	

--- a/packages/Sandblocks-Babylonian/SBExample.class.st
+++ b/packages/Sandblocks-Babylonian/SBExample.class.st
@@ -126,6 +126,19 @@ SBExample >> assertionBlock [
 	^ self submorphCount > 7 ifTrue: [self submorphs ninth] ifFalse: [nil]
 ]
 
+{ #category : #actions }
+SBExample >> backtrack [
+	<action>
+	
+	SBExploriants uniqueInstance isInEditor 
+		ifTrue: [
+			self sandblockEditor openMorphInView: 
+				(SBExploriants uniqueInstance historyView backtrackForExample: self)] 
+
+	
+	
+]
+
 { #category : #'event handling' }
 SBExample >> click: anEvent [
 

--- a/packages/Sandblocks-Babylonian/SBExample.class.st
+++ b/packages/Sandblocks-Babylonian/SBExample.class.st
@@ -25,7 +25,7 @@ SBExample class >> instanceSuggestion [
 		self new
 			self: SBStGrammarHandler new newNullBlock
 			args: (SBStArray new type: #dynamic)
-			label: 'example']
+			label: self nameSuggestion]
 ]
 
 { #category : #'as yet unclassified' }
@@ -45,6 +45,12 @@ SBExample class >> matches: aMessage [
 SBExample class >> matchingSelectors [
 
 	^ #(#self:args:label: #self:args:label:assert: #example:args:label: #example:args:label:assert:)
+]
+
+{ #category : #'as yet unclassified' }
+SBExample class >> nameSuggestion [
+
+	^ 'example {1}' format: {Random generateInteger}
 ]
 
 { #category : #'as yet unclassified' }

--- a/packages/Sandblocks-Babylonian/SBExampleCluster.class.st
+++ b/packages/Sandblocks-Babylonian/SBExampleCluster.class.st
@@ -3,7 +3,8 @@ Class {
 	#superclass : #SBCluster,
 	#instVars : [
 		'displayedIndex',
-		'multiverse'
+		'examples',
+		'universes'
 	],
 	#category : #'Sandblocks-Babylonian'
 }
@@ -13,7 +14,8 @@ SBExampleCluster class >> newForSize: aSBMorphResizer multiverse: aSBMultiverse 
 
 	^ self new 
 		morphResizer: aSBMorphResizer;
-		multiverse: aSBMultiverse;
+		universes: aSBMultiverse universes;
+		examples: aSBMultiverse activeExamples; 
 		displayedIndex: aNumber;
 		visualize;
 		yourself 
@@ -25,15 +27,15 @@ SBExampleCluster >> buildDisplayMatrix [
 
 	| matrix |
 	matrix := Matrix 
-		rows: (self multiverse universes first watches size) + 1
-		columns: self multiverse universes size + 1.
+		rows: self universes first watches size + 1
+		columns: self universes size + 1.
 		
 	matrix atRow: 1 put: ({self newTopLeftCornerPlaceholder}, 
-		(self extractedTopHeadingsFrom: self multiverse)).
+		(self extractedTopHeadingsFrom: self universes)).
 	matrix atColumn: 1 put: ({self newTopLeftCornerPlaceholder}, 
-		(self extractedLeftHeadingsFrom: self multiverse)).
+		(self extractedLeftHeadingsFrom: self universes first watches)).
 	
-	self multiverse universes withIndexDo: [:aUniverse :column | 
+	self universes withIndexDo: [:aUniverse :column | 
 		(self extractRowsFrom: aUniverse) withIndexDo: [:aCellMorph :row| 
 			matrix at: row+1 at: column+1 put: aCellMorph]].
 
@@ -52,41 +54,45 @@ SBExampleCluster >> displayedIndex: aNumber [
 	displayedIndex := aNumber
 ]
 
+{ #category : #accessing }
+SBExampleCluster >> examples [
+
+	^ examples
+]
+
+{ #category : #accessing }
+SBExampleCluster >> examples: aCollectionOfSBExamples [
+	
+	examples := aCollectionOfSBExamples
+]
+
 { #category : #visualisation }
 SBExampleCluster >> extractRowsFrom: aUniverse [
 
 	^ aUniverse watches collect: [:aWatch | | display | 
-		display := (aWatch exampleToDisplay at: (self multiverse activeExamples at: self displayedIndex)) value display.
-		self compressedMorphsForDisplay: display]
+		display := (aWatch exampleToDisplay at: (self examples at: self displayedIndex)) value display.
+		(self compressedMorphsForDisplay: display) 
+			tag: ((SBTag newFromWatch: aWatch) addFromPermutation: aUniverse activePermutation)]
 ]
 
 { #category : #visualisation }
-SBExampleCluster >> extractedLeftHeadingsFrom: aSBMultiverse [
+SBExampleCluster >> extractedLeftHeadingsFrom: aCollectionOfSBExampleWatches [
 
-	^ (aSBMultiverse universes first watches collect: [:aWatch | aWatch expression copy])
+	^ (aCollectionOfSBExampleWatches collect: [:aWatch | 
+		aWatch expression copy
+			tag: (SBTag newFromWatch: aWatch)])
 ]
 
 { #category : #visualisation }
-SBExampleCluster >> extractedTopHeadingsFrom: aSBMultiverse [
+SBExampleCluster >> extractedTopHeadingsFrom: aCollectionOfSBUniverses [
 
-	^ (aSBMultiverse universes collect: [:aUniverse | 
-			SBPermutationLabel newDisplaying: aUniverse activePermutation])
-]
-
-{ #category : #accessing }
-SBExampleCluster >> multiverse [
-
-	^ multiverse
-]
-
-{ #category : #accessing }
-SBExampleCluster >> multiverse: aSBMultiverse [
-
-	multiverse := aSBMultiverse
+	^ aCollectionOfSBUniverses collect: [:aUniverse | 
+		(SBPermutationLabel newDisplaying: aUniverse activePermutation)
+			tag:  (SBTag newFromPermutation: aUniverse activePermutation)]
 ]
 
 { #category : #visualisation }
-SBExampleCluster >> newTopRowFrom: aCollectionOfPermutationLabels [
+SBExampleCluster >> newTopRowFrom: aCollectionOfTaggedLabels [
 	
 	"Width should be set, but height can vary"
 	^ self newContainerMorph 
@@ -94,16 +100,17 @@ SBExampleCluster >> newTopRowFrom: aCollectionOfPermutationLabels [
 		listCentering: #bottomRight;
 		cellPositioning: #topCenter;
 		hResizing: #spaceFill;
-		addAllMorphsBack: (aCollectionOfPermutationLabels collect: [:aLabel | 
+		addAllMorphsBack: (aCollectionOfTaggedLabels collect: [:aTaggedLabel | 
 			| wrappedLabel button |
-			aLabel rotationDegrees: 90.
-			wrappedLabel := (self wrapInCell: aLabel owner 
+			aTaggedLabel rotationDegrees: 90.
+			wrappedLabel := (self wrapInCell: aTaggedLabel owner 
 										flexVertically: true 
 										flexHorizontally: false) borderWidth: 0.
 			"Rotating morphs somehow clips their right border, so dirty hack so container gets clipped 1px"
 			button := self newContainerMorph 
+				tag:  (SBTag newFromPermutation: aTaggedLabel permutation);
 				cellInset: 1;
-				addMorphBack: (SBButton newApplyPermutationFor: aLabel permutation);
+				addMorphBack: (SBButton newApplyPermutationFor: aTaggedLabel permutation);
 				rotationDegrees: 90.
 			button owner width > wrappedLabel width ifTrue: [button firstSubmorph makeTiny].
 			
@@ -112,4 +119,16 @@ SBExampleCluster >> newTopRowFrom: aCollectionOfPermutationLabels [
 				cellPositioning: #topCenter;
 				cellInset: 0@2;
 				addAllMorphsBack: {button owner. wrappedLabel}])
+]
+
+{ #category : #accessing }
+SBExampleCluster >> universes [
+
+	^ universes
+]
+
+{ #category : #accessing }
+SBExampleCluster >> universes: aCollectionOfSBUniverses [
+
+	universes := aCollectionOfSBUniverses
 ]

--- a/packages/Sandblocks-Babylonian/SBExampleCluster.class.st
+++ b/packages/Sandblocks-Babylonian/SBExampleCluster.class.st
@@ -92,7 +92,7 @@ SBExampleCluster >> extractedTopHeadingsFrom: aCollectionOfSBUniverses [
 ]
 
 { #category : #visualisation }
-SBExampleCluster >> newTopRowFrom: aCollectionOfTaggedLabels [
+SBExampleCluster >> newTopRowFrom: aCollectionOfPermutationLabels [
 	
 	"Width should be set, but height can vary"
 	^ self newContainerMorph 
@@ -100,17 +100,17 @@ SBExampleCluster >> newTopRowFrom: aCollectionOfTaggedLabels [
 		listCentering: #bottomRight;
 		cellPositioning: #topCenter;
 		hResizing: #spaceFill;
-		addAllMorphsBack: (aCollectionOfTaggedLabels collect: [:aTaggedLabel | 
+		addAllMorphsBack: (aCollectionOfPermutationLabels collect: [:aLabel | 
 			| wrappedLabel button |
-			aTaggedLabel rotationDegrees: 90.
-			wrappedLabel := (self wrapInCell: aTaggedLabel owner 
+			aLabel rotationDegrees: 90.
+			wrappedLabel := (self wrapInCell: aLabel owner 
 										flexVertically: true 
 										flexHorizontally: false) borderWidth: 0.
 			"Rotating morphs somehow clips their right border, so dirty hack so container gets clipped 1px"
 			button := self newContainerMorph 
-				tag:  (SBTag newFromPermutation: aTaggedLabel permutation);
+				tag:  (SBTag newFromPermutation: aLabel permutation);
 				cellInset: 1;
-				addMorphBack: (SBButton newApplyPermutationFor: aTaggedLabel permutation);
+				addMorphBack: (SBButton newApplyPermutationFor: aLabel permutation);
 				rotationDegrees: 90.
 			button owner width > wrappedLabel width ifTrue: [button firstSubmorph makeTiny].
 			

--- a/packages/Sandblocks-Babylonian/SBExampleGridsView.class.st
+++ b/packages/Sandblocks-Babylonian/SBExampleGridsView.class.st
@@ -17,15 +17,19 @@ SBExampleGridsView >> buildAllPossibleResults [
 { #category : #building }
 SBExampleGridsView >> buildExampleFor: aNumber [
 		
-	gridContainer addMorphBack: (self containerRow cellPositioning: #center;
-		addAllMorphsBack: {
-			self containerRow listDirection: #topToBottom;
-				addAllMorphsBack: { 
-					SBOwnTextMorph new contents: 'example: ', (self multiverse activeExamples at: aNumber) label.
-					self currentClusterClass
-						newForSize: self selectedResizer
-						multiverse: self multiverse 
-						displaying: aNumber}})
+	gridContainer addMorphBack: (
+		self containerRow 
+			cellPositioning: #center;
+			tag: (SBTag newFromExample: (self multiverse activeExamples at: aNumber));
+			addAllMorphsBack: {
+				self containerRow 
+					listDirection: #topToBottom;
+					addAllMorphsBack: { 
+						SBOwnTextMorph new contents: 'example: ', (self multiverse activeExamples at: aNumber) label.
+						self currentClusterClass
+							newForSize: self selectedResizer
+							multiverse: self multiverse 
+							displaying: aNumber}})
 ]
 
 { #category : #accessing }

--- a/packages/Sandblocks-Babylonian/SBExampleTrace.class.st
+++ b/packages/Sandblocks-Babylonian/SBExampleTrace.class.st
@@ -10,11 +10,11 @@ SBExampleTrace >> buildDisplayMatrix [
 	| matrix displayedExample |
 	matrix := Matrix 
 		rows: 2
-		columns: self multiverse universes size.
-	displayedExample := self multiverse activeExamples at: self displayedIndex. 
+		columns: self universes size.
+	displayedExample := self examples at: self displayedIndex. 
 		
-	matrix atRow: 1 put: (self extractedTopHeadingsFrom: self multiverse).
-	self multiverse universes withIndexDo: [:aUniverse :column | 
+	matrix atRow: 1 put: (self extractedTopHeadingsFrom: self universes).
+	self universes withIndexDo: [:aUniverse :column | 
 		matrix 
 			at: 2 
 			at: column 
@@ -31,7 +31,7 @@ SBExampleTrace >> visualize [
 
 	| matrix |
 	self submorphs copy do: #delete.
-	self multiverse watches ifEmpty: [self visualizeNothingToDisplay. ^ self].
+	self universes first watches ifEmpty: [self visualizeNothingToDisplay. ^ self].
 	
 	matrix := self buildDisplayMatrix.
 	self addAllMorphsBack: {self newContainerMorph 
@@ -44,7 +44,8 @@ SBExampleTrace >> visualize [
 						self newContainerMorph
 							wrapCentering: #center;
 							hResizing: #spaceFill;
-							addMorphBack: (matrix at: 1 at: i)))
+							addMorphBack: (matrix at: 1 at: i);
+							tag: (SBTag newFromPermutation: ((self universes at: i) activePermutation))))
 					flexVertically: true 
 					flexHorizontally: true ])}
 ]

--- a/packages/Sandblocks-Babylonian/SBExampleWatch.class.st
+++ b/packages/Sandblocks-Babylonian/SBExampleWatch.class.st
@@ -149,6 +149,17 @@ SBExampleWatch >> asInactiveCopy [
 		yourself
 ]
 
+{ #category : #actions }
+SBExampleWatch >> backtrack [
+	<action>
+
+	SBExploriants uniqueInstance isInEditor 
+		ifTrue: [
+			self sandblockEditor openMorphInView: 
+				(SBExploriants uniqueInstance historyView backtrackForWatch: self)] 
+
+]
+
 { #category : #initialization }
 SBExampleWatch >> buildDefaultDisplayFor: anExample [
 
@@ -355,12 +366,7 @@ SBExampleWatch >> initialize [
 				listCentering: #bottomRight;
 				addMorphBack: dimensionOptions;
 				yourself.
-			SBVariant
-				named: 'modifyExpression'
-				associations: {'with' -> [modifyExpression]. 'without' -> []}
-				activeIndex: 2
-				id: '90d7c718-89b8-7e48-8262-467d07d56880'
-				isActive: false};
+			modifyExpression}
 		yourself
 ]
 

--- a/packages/Sandblocks-Babylonian/SBExampleWatch.class.st
+++ b/packages/Sandblocks-Babylonian/SBExampleWatch.class.st
@@ -153,10 +153,7 @@ SBExampleWatch >> asInactiveCopy [
 SBExampleWatch >> backtrack [
 	<action>
 
-	SBExploriants uniqueInstance isInEditor 
-		ifTrue: [
-			self sandblockEditor openMorphInView: 
-				(SBExploriants uniqueInstance historyView backtrackForWatch: self)] 
+	SBExploriants backtrack: #backtrackForWatch: withArguments: {self}
 
 ]
 

--- a/packages/Sandblocks-Babylonian/SBExploriants.class.st
+++ b/packages/Sandblocks-Babylonian/SBExploriants.class.st
@@ -17,6 +17,16 @@ Class {
 }
 
 { #category : #accessing }
+SBExploriants class >> backtrack: aSymbol withArguments: argArray [
+
+	self uniqueInstance isInEditor 
+		ifTrue: [
+			self uniqueInstance sandblockEditor openMorphInView:
+				(self uniqueInstance historyView perform: aSymbol withArguments: argArray)] 
+
+]
+
+{ #category : #accessing }
 SBExploriants class >> deleteUniqueInstance [ 
 
 	uniqueInstance := nil

--- a/packages/Sandblocks-Babylonian/SBExploriants.class.st
+++ b/packages/Sandblocks-Babylonian/SBExploriants.class.st
@@ -118,6 +118,12 @@ SBExploriants >> evaluationReceiver [
 ]
 
 { #category : #accessing }
+SBExploriants >> historyView [ 
+
+	^ self namedBlocks detect: #isHistoryView 
+]
+
+{ #category : #accessing }
 SBExploriants >> ignoreUpdate [
 
 	^ ignoreUpdate

--- a/packages/Sandblocks-Babylonian/SBExploriantsView.class.st
+++ b/packages/Sandblocks-Babylonian/SBExploriantsView.class.st
@@ -31,6 +31,20 @@ SBExploriantsView class >> newMultiverse: aSBMultiverse [
 ]
 
 { #category : #building }
+SBExploriantsView >> buildBlock [
+
+	^ SBBlock new
+		changeTableLayout;
+		color: Color white;
+		listDirection: #topToBottom;
+		layoutInset: 3;
+		cellGap: 4;
+		cellInset: 2;
+		hResizing: #shrinkWrap;
+		vResizing: #shrinkWrap
+]
+
+{ #category : #building }
 SBExploriantsView >> buildButtonRow [ 
 
 	self block addMorphFront: (SBRow new
@@ -82,15 +96,13 @@ SBExploriantsView >> initialize [
 
 	super initialize.
 	
-	self block: (SBBlock new
-		changeTableLayout;
-		color: Color white;
-		listDirection: #topToBottom;
-		layoutInset: 3;
-		cellGap: 4;
-		cellInset: 2;
-		hResizing: #shrinkWrap;
-		vResizing: #shrinkWrap).
+	self block: self buildBlock.
+]
+
+{ #category : #accessing }
+SBExploriantsView >> isHistoryView [
+
+	^ false
 ]
 
 { #category : #accessing }
@@ -134,9 +146,9 @@ SBExploriantsView >> saveButton [
 ]
 
 { #category : #copying }
-SBExploriantsView >> snapshot [
+SBExploriantsView >> snapshotSatisfying: aCollectionOfSBTags [
 
-	^ ImageMorph new newForm: self block imageForm
+	^ self block snapshotSatisfying: aCollectionOfSBTags
 ]
 
 { #category : #building }

--- a/packages/Sandblocks-Babylonian/SBHistoryEpoche.class.st
+++ b/packages/Sandblocks-Babylonian/SBHistoryEpoche.class.st
@@ -34,8 +34,9 @@ SBHistoryEpoche >> buildMetaUsage [
 SBHistoryEpoche >> buildSnapshotTabView [
 
 	^ SBTabView 
-		namedBlocks: (self tabsToSnapshot
-							collect: [:aTab | SBNamedBlock block: aTab snapshot named: aTab name]) 
+		namedBlocks: (
+			self tabsToSnapshot
+				collect: [:aTab | SBNamedBlock block: aTab snapshot named: aTab name]) 
 		activeIndex: (SBExploriants uniqueInstance namedBlocks detect: #isOverview) activeIndex
 	
 ]
@@ -80,7 +81,7 @@ SBHistoryEpoche >> initialize [
 		
 	self addAllMorphsBack: {
 		self buildMetaUsage. 
-		tabview := self buildSnapshotTabView.}
+		tabview := self buildSnapshotTabView}
 ]
 
 { #category : #accessing }

--- a/packages/Sandblocks-Babylonian/SBHistoryEpoche.class.st
+++ b/packages/Sandblocks-Babylonian/SBHistoryEpoche.class.st
@@ -1,0 +1,135 @@
+Class {
+	#name : #SBHistoryEpoche,
+	#superclass : #SBRow,
+	#instVars : [
+		'deleteButton',
+		'timestamp',
+		'notes',
+		'tabview'
+	],
+	#category : #'Sandblocks-Babylonian'
+}
+
+{ #category : #building }
+SBHistoryEpoche >> buildDeleteButton [
+
+	^ SBButton new
+		icon: SBIcon iconTrash
+			do: [self delete];
+		balloonText: 'Delete this row';
+		cornerStyle: #squared;
+		makeSmall
+]
+
+{ #category : #building }
+SBHistoryEpoche >> buildMetaUsage [
+
+	^ self containerRow
+		addAllMorphsBack: { deleteButton := self buildDeleteButton.
+			timestamp := TextMorph new contents: (Text fromString: TimeStamp current asStringOrText) allBold.
+			notes := SBLabel new contents: 'Notes'}
+]
+
+{ #category : #building }
+SBHistoryEpoche >> buildSnapshotTabView [
+
+	^ SBTabView 
+		namedBlocks: (self tabsToSnapshot
+							collect: [:aTab | SBNamedBlock block: aTab snapshot named: aTab name]) 
+		activeIndex: (SBExploriants uniqueInstance namedBlocks detect: #isOverview) activeIndex
+	
+]
+
+{ #category : #building }
+SBHistoryEpoche >> containerRow [
+
+	^ SBRow new
+		color: Color transparent;
+		vResizing: #shrinkWrap;
+		hResizing: #shrinkWrap;
+		cellPositioning: #topLeft;
+		changeTableLayout;
+		listDirection: #leftToRight;
+		layoutInset: 2;
+		cellGap: 5@0;
+		cellInset: 2;
+		borderWidth: 0
+]
+
+{ #category : #accessing }
+SBHistoryEpoche >> deleteButton [
+
+	^ deleteButton
+]
+
+{ #category : #initialization }
+SBHistoryEpoche >> initialize [ 
+
+	super initialize.
+	
+	self color: Color transparent;
+		vResizing: #shrinkWrap;
+		hResizing: #shrinkWrap;
+		cellPositioning: #topLeft;
+		changeTableLayout;
+		listDirection: #topToBottom;
+		layoutInset: 2;
+		cellGap: 0@10; 
+		cellInset: 2;
+		borderWidth: 0.
+		
+	self addAllMorphsBack: {
+		self buildMetaUsage. 
+		tabview := self buildSnapshotTabView.}
+]
+
+{ #category : #accessing }
+SBHistoryEpoche >> notes [
+
+	^ notes
+]
+
+{ #category : #'*Sandblocks-Babylonian' }
+SBHistoryEpoche >> privateSnapshotSatisfying: aCollectionOfSBTags from: originalEpoche [
+
+	self removeAllMorphs.
+	self addAllMorphsBack: {
+		self snapshotMetaUsageTimeStamp: originalEpoche timestamp notes: originalEpoche notes.
+		tabview snapshotSatisfying: aCollectionOfSBTags}
+]
+
+{ #category : #accessing }
+SBHistoryEpoche >> setIndexTo: aNewIndex [
+
+	tabview activeIndex: aNewIndex
+]
+
+{ #category : #'*Sandblocks-Babylonian' }
+SBHistoryEpoche >> snapshotMetaUsageTimeStamp: oldStamp notes: oldNotes [
+
+	^ self containerRow
+		addAllMorphsBack: { deleteButton := self buildDeleteButton.
+			timestamp := TextMorph new contents: oldStamp contents.
+			notes := SBLabel new contents: oldNotes contents};
+		yourself
+]
+
+{ #category : #'*Sandblocks-Babylonian' }
+SBHistoryEpoche >> snapshotSatisfying: aCollectionOfSBTags [
+
+	^ self class new
+		setIndexTo: tabview activeIndex; 
+		privateSnapshotSatisfying: aCollectionOfSBTags from: self
+]
+
+{ #category : #accessing }
+SBHistoryEpoche >> tabsToSnapshot [
+
+	^ (SBExploriants uniqueInstance namedBlocks detect: #isOverview) views 
+]
+
+{ #category : #accessing }
+SBHistoryEpoche >> timestamp [
+
+	^ timestamp
+]

--- a/packages/Sandblocks-Babylonian/SBHistoryEpoche.extension.st
+++ b/packages/Sandblocks-Babylonian/SBHistoryEpoche.extension.st
@@ -1,0 +1,28 @@
+Extension { #name : #SBHistoryEpoche }
+
+{ #category : #'*Sandblocks-Babylonian' }
+SBHistoryEpoche >> privateSnapshotSatisfying: aCollectionOfSBTags from: originalEpoche [
+
+	self removeAllMorphs.
+	self addAllMorphsBack: {
+		self snapshotMetaUsageTimeStamp: originalEpoche timestamp notes: originalEpoche notes.
+		tabview snapshotSatisfying: aCollectionOfSBTags}
+]
+
+{ #category : #'*Sandblocks-Babylonian' }
+SBHistoryEpoche >> snapshotMetaUsageTimeStamp: oldStamp notes: oldNotes [
+
+	^ self containerRow
+		addAllMorphsBack: { deleteButton := self buildDeleteButton.
+			timestamp := TextMorph new contents: oldStamp contents.
+			notes := SBLabel new contents: oldNotes contents};
+		yourself
+]
+
+{ #category : #'*Sandblocks-Babylonian' }
+SBHistoryEpoche >> snapshotSatisfying: aCollectionOfSBTags [
+
+	^ self class new
+		setIndexTo: tabview activeIndex; 
+		privateSnapshotSatisfying: aCollectionOfSBTags from: self
+]

--- a/packages/Sandblocks-Babylonian/SBHistoryView.class.st
+++ b/packages/Sandblocks-Babylonian/SBHistoryView.class.st
@@ -12,38 +12,29 @@ SBHistoryView >> addEpoche [
 	self block addMorph: self buildEpoche atIndex: 2
 ]
 
+{ #category : #accessing }
+SBHistoryView >> backtrackForExample: aSBExample [
+
+	^ self copySatisfying: {SBTag newFromExample: aSBExample}
+]
+
+{ #category : #accessing }
+SBHistoryView >> backtrackForPermutationName: aString [
+
+	^ self copySatisfying: {SBTag new permutationName: aString}
+]
+
+{ #category : #accessing }
+SBHistoryView >> backtrackForWatch: aSBWatch [
+
+	^ self copySatisfying: {SBTag newFromWatch: aSBWatch}
+]
+
 { #category : #building }
 SBHistoryView >> buildEpoche [
 
-	| row |
-	row := self containerRow.
-	^ row
-		cellGap: 0@10; 
-		listDirection: #topToBottom; 
-		addAllMorphsBack: {self buildMetaUsageIn: row. self buildSnapshotTabView}
+	^ SBHistoryEpoche new
 	
-	
-]
-
-{ #category : #building }
-SBHistoryView >> buildMetaUsageIn: aRow [
-
-	^ self containerRow
-		cellGap: 5@0;
-		addAllMorphsBack: {self deleteEpocheButton: aRow. 
-								TextMorph new contents: (Text fromString: TimeStamp current asStringOrText) allBold.
-								SBLabel new contents: 'Notes'}
-	
-	
-]
-
-{ #category : #building }
-SBHistoryView >> buildSnapshotTabView [
-
-	^ SBTabView 
-		namedBlocks: (self tabsToSnapshot
-							collect: [:aTab | SBNamedBlock block: aTab snapshot named: aTab name]) 
-		activeIndex: (SBExploriants uniqueInstance namedBlocks detect: #isOverview) activeIndex
 	
 ]
 
@@ -73,17 +64,20 @@ SBHistoryView >> clearButton [
 		cornerStyle: #squared
 ]
 
-{ #category : #building }
-SBHistoryView >> deleteEpocheButton: theRow [
+{ #category : #accessing }
+SBHistoryView >> copySatisfying: aCollectionOfSBTags [
 
-	^ SBButton new
-		icon: SBIcon iconTrash
-			do: [theRow delete];
-		balloonText: 'Delete this row';
-		cornerStyle: #squared;
-		makeSmall
-	
-	
+	| interactiveCopy |
+	interactiveCopy := self buildBlock.
+	self block submorphs allButFirstDo: [:anEpoche |
+		interactiveCopy addMorphBack: (anEpoche snapshotSatisfying: aCollectionOfSBTags)].
+	^ interactiveCopy
+]
+
+{ #category : #accessing }
+SBHistoryView >> epoches [
+
+	^ self block submorphs allButFirst
 ]
 
 { #category : #initialization }
@@ -93,6 +87,12 @@ SBHistoryView >> initialize [
 	
 	self name: 'History'.
 	self buildButtonRow.
+]
+
+{ #category : #accessing }
+SBHistoryView >> isHistoryView [
+
+	^ true
 ]
 
 { #category : #accessing }
@@ -109,7 +109,7 @@ SBHistoryView >> offerChangeTabMenu [
 	index := UIManager default chooseFrom: options.
 	index = 0 ifTrue: [^ self].
 	
-	self block submorphs allButFirst do: [:anEpoche | anEpoche lastSubmorph activeIndex: index].
+	self epoches do: [:anEpoche | anEpoche setIndexTo: index].
 ]
 
 { #category : #building }

--- a/packages/Sandblocks-Babylonian/SBHistoryView.class.st
+++ b/packages/Sandblocks-Babylonian/SBHistoryView.class.st
@@ -67,11 +67,11 @@ SBHistoryView >> clearButton [
 { #category : #accessing }
 SBHistoryView >> copySatisfying: aCollectionOfSBTags [
 
-	| interactiveCopy |
-	interactiveCopy := self buildBlock.
-	self block submorphs allButFirstDo: [:anEpoche |
-		interactiveCopy addMorphBack: (anEpoche snapshotSatisfying: aCollectionOfSBTags)].
-	^ interactiveCopy
+	^ self buildBlock
+		addAllMorphsBack: (
+			self epoches 
+				collect: [:anEpoche | anEpoche snapshotSatisfying: aCollectionOfSBTags]);
+		yourself 
 ]
 
 { #category : #accessing }

--- a/packages/Sandblocks-Babylonian/SBLineChart.extension.st
+++ b/packages/Sandblocks-Babylonian/SBLineChart.extension.st
@@ -1,0 +1,19 @@
+Extension { #name : #SBLineChart }
+
+{ #category : #'*Sandblocks-Babylonian' }
+SBLineChart >> layoutedTaggedCopy [
+
+	^ self class new
+		traceValues: self traceValues;
+		targetHeight: self targetHeight;
+		scaleY: self scaleY;
+		extent: self extent;
+		color: self color;
+		layoutProperties: self layoutProperties;
+		layoutPolicy: self layoutPolicy;
+		borderStyle: self borderStyle;
+		tag: self tag;
+		yourself 
+				
+		
+]

--- a/packages/Sandblocks-Babylonian/SBLiveView.class.st
+++ b/packages/Sandblocks-Babylonian/SBLiveView.class.st
@@ -35,7 +35,9 @@ SBLiveView >> buildPreviewFor: aPermutation [
 	
 	| preview |	
 	preview := self newRegisteredListenerFor: aPermutation.
-	gridContainer addMorphBack: (self containerRow cellPositioning: #center;
+	gridContainer addMorphBack: (self containerRow 
+		cellPositioning: #center;
+		tag: (SBTag newFromPermutation: aPermutation);
 		addAllMorphsBack: {
 			self containerRow listDirection: #topToBottom;
 				 addAllMorphsBack: { 
@@ -219,13 +221,13 @@ SBLiveView >> setUpMorph [
 ]
 
 { #category : #copying }
-SBLiveView >> snapshot [
+SBLiveView >> snapshotSatisfying: aCollectionOfSBTags [
 						
 	^ self containerRow 
 				listDirection: #topToBottom;
 				addAllMorphsBack: {
 					ImageMorph new newForm: (self block submorphNamed: 'setup') imageForm.
-					ImageMorph new newForm: gridContainer imageForm}
+					gridContainer snapshotSatisfying: aCollectionOfSBTags}
 ]
 
 { #category : #building }

--- a/packages/Sandblocks-Babylonian/SBNilTag.class.st
+++ b/packages/Sandblocks-Babylonian/SBNilTag.class.st
@@ -1,0 +1,35 @@
+Class {
+	#name : #SBNilTag,
+	#superclass : #SBTag,
+	#category : #'Sandblocks-Babylonian'
+}
+
+{ #category : #accessing }
+SBNilTag >> isNilTag [ 
+
+	^ true 
+]
+
+{ #category : #filtering }
+SBNilTag >> satisfiesExampleLabel: aString [
+
+	^ false
+]
+
+{ #category : #filtering }
+SBNilTag >> satisfiesTag: anotherTag [
+
+	^ false
+]
+
+{ #category : #filtering }
+SBNilTag >> satisfiesVariantId: aString [
+
+	^ false
+]
+
+{ #category : #filtering }
+SBNilTag >> satisfiesWatchId: aString [
+
+	^ false
+]

--- a/packages/Sandblocks-Babylonian/SBOwnTextMorph.extension.st
+++ b/packages/Sandblocks-Babylonian/SBOwnTextMorph.extension.st
@@ -1,0 +1,12 @@
+Extension { #name : #SBOwnTextMorph }
+
+{ #category : #'*Sandblocks-Babylonian' }
+SBOwnTextMorph >> layoutedTaggedCopy [
+
+	^ super layoutedTaggedCopy 
+		font: self font;
+		colorAlpha: self colorAlpha;
+		emphasis: self emphasis;
+		contents: '';
+		yourself 
+]

--- a/packages/Sandblocks-Babylonian/SBPermutationCluster.class.st
+++ b/packages/Sandblocks-Babylonian/SBPermutationCluster.class.st
@@ -40,22 +40,45 @@ SBPermutationCluster >> buildDisplayMatrix [
 ]
 
 { #category : #visualisation }
-SBPermutationCluster >> extractColumnsFrom: aCollectionOfSBExampleWatches [
+SBPermutationCluster >> extractColumnsFrom: aSBExampleWatch [
 
-	^ aCollectionOfSBExampleWatches exampleToDisplay collect: [:anExampleValueDisplay | 
-		self compressedMorphsForDisplay: anExampleValueDisplay display]
+	^ aSBExampleWatch exampleToDisplay collect: [:anExampleValueDisplay | 
+		(self compressedMorphsForDisplay: anExampleValueDisplay display)
+			tag: ((SBTag 
+				newFromExample: (aSBExampleWatch exampleToDisplay keyAtValue: anExampleValueDisplay))
+				addFromWatch: aSBExampleWatch)]
 ]
 
 { #category : #visualisation }
 SBPermutationCluster >> extractedLeftHeadingsFrom: aCollectionOfSBExampleWatches [
 
-	^ (aCollectionOfSBExampleWatches collect: [:aWatch | aWatch expression copy])
+	^ (aCollectionOfSBExampleWatches collect: [:aWatch | 
+			aWatch expression copy 
+				tag: (SBTag newFromWatch: aWatch)])
 ]
 
 { #category : #visualisation }
 SBPermutationCluster >> extractedTopHeadingsFrom: aCollectionOfSBExampleWatches [
 
-	^ (aCollectionOfSBExampleWatches first exampleToDisplay values collect: [:aDisplay | aDisplay labelMorph copy])
+	^ (aCollectionOfSBExampleWatches first exampleToDisplay values collect: [:aDisplay | 
+		aDisplay labelMorph copy
+			tag: (SBTag new exampleLabel: aDisplay labelMorph contents)])
+]
+
+{ #category : #visualisation }
+SBPermutationCluster >> newTopRowFrom: aCollectionOfExampleLabels [
+	
+	"Width should be set, but height can vary"
+	^ self newContainerMorph 
+		listDirection: #leftToRight;
+		listCentering: #bottomRight;
+		cellPositioning: #topCenter;
+		hResizing: #spaceFill;
+		addAllMorphsBack: (aCollectionOfExampleLabels collect: [:aLabel | 
+			aLabel rotationDegrees: 90.
+			(self wrapInCell: aLabel owner 
+				flexVertically: true 
+				flexHorizontally: false) borderWidth: 0])
 ]
 
 { #category : #accessing }

--- a/packages/Sandblocks-Babylonian/SBPermutationCluster.class.st
+++ b/packages/Sandblocks-Babylonian/SBPermutationCluster.class.st
@@ -65,22 +65,6 @@ SBPermutationCluster >> extractedTopHeadingsFrom: aCollectionOfSBExampleWatches 
 			tag: (SBTag new exampleLabel: aDisplay labelMorph contents)])
 ]
 
-{ #category : #visualisation }
-SBPermutationCluster >> newTopRowFrom: aCollectionOfExampleLabels [
-	
-	"Width should be set, but height can vary"
-	^ self newContainerMorph 
-		listDirection: #leftToRight;
-		listCentering: #bottomRight;
-		cellPositioning: #topCenter;
-		hResizing: #spaceFill;
-		addAllMorphsBack: (aCollectionOfExampleLabels collect: [:aLabel | 
-			aLabel rotationDegrees: 90.
-			(self wrapInCell: aLabel owner 
-				flexVertically: true 
-				flexHorizontally: false) borderWidth: 0])
-]
-
 { #category : #accessing }
 SBPermutationCluster >> watches [
 

--- a/packages/Sandblocks-Babylonian/SBPermutationGridsView.class.st
+++ b/packages/Sandblocks-Babylonian/SBPermutationGridsView.class.st
@@ -15,7 +15,9 @@ SBPermutationGridsView >> buildPermutationFor: aSBUniverse [
 		
 	gridContainer addMorphBack: (self containerRow cellPositioning: #center;
 		addAllMorphsBack: {
-			self containerRow listDirection: #topToBottom;
+			self containerRow 
+				listDirection: #topToBottom;
+				tag: (SBTag newFromPermutation: aSBUniverse activePermutation);
 				addAllMorphsBack: { 
 					SBPermutationLabel newDisplaying: aSBUniverse activePermutation.
 					SBButton newApplyPermutationFor: aSBUniverse activePermutation. 

--- a/packages/Sandblocks-Babylonian/SBRectangleChart.extension.st
+++ b/packages/Sandblocks-Babylonian/SBRectangleChart.extension.st
@@ -1,0 +1,20 @@
+Extension { #name : #SBRectangleChart }
+
+{ #category : #'*Sandblocks-Babylonian' }
+SBRectangleChart >> layoutedTaggedCopy [
+
+	^ self class new
+		traceValues: self traceValues;
+		targetHeight: self targetHeight;
+		scaleY: self scaleY;
+		scaleX: self scaleX;
+		extent: self extent;
+		color: self color;
+		layoutProperties: self layoutProperties;
+		layoutPolicy: self layoutPolicy;
+		borderStyle: self borderStyle;
+		tag: self tag;
+		yourself 
+				
+		
+]

--- a/packages/Sandblocks-Babylonian/SBStGrammarHandler.extension.st
+++ b/packages/Sandblocks-Babylonian/SBStGrammarHandler.extension.st
@@ -41,7 +41,7 @@ SBStGrammarHandler >> createExampleIn: aMethod classed: aClass [
 				type: #dynamic
 				contents: (aMethod arguments collect: [:anArgument | 
 					self extractBlockFromArgumentName: anArgument contents]))
-			label: 'example'.
+			label: SBExample nameSuggestion
 ]
 
 { #category : #'*Sandblocks-Babylonian' }

--- a/packages/Sandblocks-Babylonian/SBStMessageSend.extension.st
+++ b/packages/Sandblocks-Babylonian/SBStMessageSend.extension.st
@@ -5,13 +5,5 @@ SBStMessageSend >> suggestedAlternationName [
 
 	^ self isAssignment
 		ifTrue: ['{2}{1}' format: {self selector. self receiver suggestedAlternationName}]
-		ifFalse: [
-			SBVariant
-				named: 'format: to ''{1} to {2}'''
-				associations: {
-					'with sender' -> ['{1} to {2}' format: {self selector. self receiver suggestedAlternationName}].
-					'w/o sender' -> ['{1}' format: {self selector}]}
-				activeIndex: 2
-				id: '1949332c-4768-ff4a-98ba-0356e4a3f2fa'
-				isActive: false]
+		ifFalse: ['{1}' format: {self selector}]
 ]

--- a/packages/Sandblocks-Babylonian/SBSwitchableResultsView.class.st
+++ b/packages/Sandblocks-Babylonian/SBSwitchableResultsView.class.st
@@ -31,9 +31,9 @@ SBSwitchableResultsView >> initialize [
 ]
 
 { #category : #copying }
-SBSwitchableResultsView >> snapshot [
+SBSwitchableResultsView >> snapshotSatisfying: aCollectionOfSBTags [
 
-	^ ImageMorph new newForm: gridContainer imageForm
+	^ gridContainer snapshotSatisfying: aCollectionOfSBTags
 	
 ]
 

--- a/packages/Sandblocks-Babylonian/SBTag.class.st
+++ b/packages/Sandblocks-Babylonian/SBTag.class.st
@@ -1,0 +1,128 @@
+"
+Attach a SBTag to a Morph to enable filtering for a specific tag value, e.g. in the SBHistoryView. See #snapshotSatisfying: for usages 
+"
+Class {
+	#name : #SBTag,
+	#superclass : #Object,
+	#instVars : [
+		'exampleLabel',
+		'watchId',
+		'permutationName'
+	],
+	#category : #'Sandblocks-Babylonian'
+}
+
+{ #category : #'initialize-release' }
+SBTag class >> newFromExample: aSBExample [
+
+	^ self new addFromExample: aSBExample
+]
+
+{ #category : #'initialize-release' }
+SBTag class >> newFromPermutation: aSBPermutation [
+
+	^ self new addFromPermutation: aSBPermutation
+]
+
+{ #category : #'initialize-release' }
+SBTag class >> newFromWatch: aSBExampleWatch [
+
+	^ self new addFromWatch: aSBExampleWatch
+]
+
+{ #category : #accessing }
+SBTag >> addFromExample: aSBExample [
+
+	self exampleLabel: aSBExample label 
+]
+
+{ #category : #accessing }
+SBTag >> addFromPermutation: aSBPermutation [
+
+	self permutationName: aSBPermutation asString 
+]
+
+{ #category : #accessing }
+SBTag >> addFromWatch: aSBExampleWatch [
+	
+	aSBExampleWatch isActive
+		ifTrue: [self watchId: aSBExampleWatch identifier asString] 
+		ifFalse: [self watchId: aSBExampleWatch originalIdentifier asString]
+	
+]
+
+{ #category : #accessing }
+SBTag >> exampleLabel [
+
+	^ exampleLabel
+]
+
+{ #category : #accessing }
+SBTag >> exampleLabel: aString [
+
+	exampleLabel := aString
+]
+
+{ #category : #accessing }
+SBTag >> isNilTag [
+
+	^ false
+]
+
+{ #category : #accessing }
+SBTag >> permutationName [
+
+	^ permutationName
+]
+
+{ #category : #accessing }
+SBTag >> permutationName: aString [
+
+	permutationName := aString
+]
+
+{ #category : #filtering }
+SBTag >> satisfiesExampleLabel: aString [
+
+	^ aString isNil 
+		or: [self exampleLabel isNil] 
+		or: [self exampleLabel includesSubstring: aString]
+]
+
+{ #category : #filtering }
+SBTag >> satisfiesTag: anotherTag [
+
+	^ (self satisfiesExampleLabel: anotherTag exampleLabel)
+		and: [self satisfiesWatchId: anotherTag watchId]
+		and: [self satisfiesVariantId: anotherTag permutationName]
+]
+
+{ #category : #filtering }
+SBTag >> satisfiesVariantId: aString [
+
+	^ aString isNil 
+		or: [self permutationName isNil] 
+		or: [self permutationName includesSubstring: aString]
+]
+
+{ #category : #filtering }
+SBTag >> satisfiesWatchId: aString [
+
+	^ aString isNil 
+		or: [self watchId isNil] 
+		or: [self watchId includesSubstring: aString]
+]
+
+{ #category : #accessing }
+SBTag >> watchId [
+
+	^ watchId
+]
+
+{ #category : #accessing }
+SBTag >> watchId: anObject [
+
+	watchId := anObject isString 
+		ifTrue: [ anObject ] 
+		ifFalse: [ anObject asString ]
+]

--- a/packages/Sandblocks-Babylonian/SBTrace.class.st
+++ b/packages/Sandblocks-Babylonian/SBTrace.class.st
@@ -12,10 +12,13 @@ SBTrace class >> newForSize: aMorphResizer example: anExample watches: aCollecti
 ]
 
 { #category : #visualization }
-SBTrace >> addSectionFor: aWatchValue resizer: aMorphResizer [
+SBTrace >> addSectionFor: aWatchValue resizer: aMorphResizer example: anExample [
 
 	self addMorphBack: (
 		self placeHolderMorph
+			tag: ((SBTag 
+				newFromWatch: aWatchValue occuringWatch)
+				addFromExample: anExample);
 			addMorphBack: (TextMorph new contents: (aWatchValue expressionString asText
 									addAttribute: (TextColor color: Color gray);
 									yourself));
@@ -70,5 +73,9 @@ SBTrace >> sortedWatchValuesFor: anExample givenWatches: aCollectionOfWatches [
 SBTrace >> visualizeFor: anExample withWatches: aCollectionOfWatches resizer: aMorphResizer [
 
 	(self sortedWatchValuesFor: anExample givenWatches: aCollectionOfWatches)
-		 do: [:aWatchValue | self addSectionFor: aWatchValue resizer: aMorphResizer]
+		 do: [:aWatchValue | 
+			self 
+				addSectionFor: aWatchValue 
+				resizer: aMorphResizer 
+				example: anExample]
 ]

--- a/packages/Sandblocks-Babylonian/StringMorph.extension.st
+++ b/packages/Sandblocks-Babylonian/StringMorph.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : #StringMorph }
+
+{ #category : #'*Sandblocks-Babylonian' }
+StringMorph >> layoutedTaggedCopy [
+
+	^ super layoutedTaggedCopy 
+		font: self font;
+		emphasis: self emphasis;
+		contents: '';
+		yourself 
+]

--- a/packages/Sandblocks-Babylonian/TransformMorph.extension.st
+++ b/packages/Sandblocks-Babylonian/TransformMorph.extension.st
@@ -1,0 +1,13 @@
+Extension { #name : #TransformMorph }
+
+{ #category : #'*Sandblocks-Babylonian' }
+TransformMorph >> layoutedTaggedCopy [
+
+	^ super layoutedTaggedCopy
+		transform: self transform;
+		smoothing: self smoothing;
+		color: Color transparent;
+		borderWidth: 0; 
+		yourself
+		
+]

--- a/packages/Sandblocks-Core/SBOwnTextMorph.extension.st
+++ b/packages/Sandblocks-Core/SBOwnTextMorph.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #SBOwnTextMorph }
+
+{ #category : #'*Sandblocks-Core' }
+SBOwnTextMorph >> fontToUse [
+
+	^ (font ifNil: [TextStyle defaultFont]) emphasized: self effectiveEmphasis emphasisCode
+]

--- a/packages/Sandblocks-Core/SBTabView.class.st
+++ b/packages/Sandblocks-Core/SBTabView.class.st
@@ -395,7 +395,8 @@ SBTabView >> removeCurrentTab [
 { #category : #tabs }
 SBTabView >> setActive: aNamedBlock [
 
-	self containingArtefact isMethod ifFalse: [self basicSetActive: aNamedBlock. ^ self].
+	(self containingArtefact isNil or: [self containingArtefact isMethod not]) 
+		ifTrue: [self basicSetActive: aNamedBlock. ^ self].
 	
 	self containingArtefact hasUnsavedChanges
 		ifTrue: [self basicSetActive: aNamedBlock] 
@@ -404,6 +405,17 @@ SBTabView >> setActive: aNamedBlock [
 			SBExploriants uniqueInstance ignoreUpdate: true.
 			self sandblockEditor save: self containingArtefact  tryFixing: false quick: true.].
 	
+]
+
+{ #category : #ui }
+SBTabView >> snapshotSatisfying: aCollectionOfSBTags [
+
+	^ SBTabView
+		namedBlocks: (self namedBlocks collect: [:aTab | 
+			SBNamedBlock 
+				block: (aTab block snapshotSatisfying: aCollectionOfSBTags)
+				named: aTab name])
+		activeIndex: self activeIndex
 ]
 
 { #category : #accessing }

--- a/packages/Sandblocks-Morphs/SBButton.class.st
+++ b/packages/Sandblocks-Morphs/SBButton.class.st
@@ -37,7 +37,7 @@ SBButton >> active: aBoolean [
 	self changed
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #updating }
 SBButton >> applyUserInterfaceTheme [
 
 	super applyUserInterfaceTheme.

--- a/packages/Sandblocks-Morphs/SBMultilineOwnTextMorph.class.st
+++ b/packages/Sandblocks-Morphs/SBMultilineOwnTextMorph.class.st
@@ -10,12 +10,6 @@ Class {
 }
 
 { #category : #'as yet unclassified' }
-SBMultilineOwnTextMorph >> adjustTextAnchor: aMorph [
-
-	
-]
-
-{ #category : #'as yet unclassified' }
 SBMultilineOwnTextMorph >> applyUserInterfaceTheme [
 
 	super applyUserInterfaceTheme.

--- a/packages/Sandblocks-Morphs/SBOwnTextMorph.class.st
+++ b/packages/Sandblocks-Morphs/SBOwnTextMorph.class.st
@@ -14,6 +14,12 @@ Class {
 }
 
 { #category : #'as yet unclassified' }
+SBOwnTextMorph >> adjustTextAnchor: aMorph [
+
+	
+]
+
+{ #category : #'as yet unclassified' }
 SBOwnTextMorph >> basicContents: aString [
 
 	contents ~= aString ifTrue: [
@@ -62,7 +68,7 @@ SBOwnTextMorph >> clearEmphasis [
 	self emphasis: TextEmphasis normal
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBOwnTextMorph >> color [
 
 	^ self sandblockForegroundColor alpha: colorAlpha
@@ -119,13 +125,13 @@ SBOwnTextMorph >> contentsToDisplay [
 	^ self contents size = 0 ifTrue: [self placeholderText] ifFalse: [self contents]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'e-toy support' }
 SBOwnTextMorph >> cursor [
 
 	^ cursor
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'e-toy support' }
 SBOwnTextMorph >> cursor: aNumber [
 
 	self basicCursor: aNumber.
@@ -223,7 +229,7 @@ SBOwnTextMorph >> displaySimpleCursorOn: aCanvas at: cursorX color: aColor [
 		line: cursorX + 1 @ self top to: cursorX + 1 @ self bottom color: (aColor alpha: 0.3)
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #drawing }
 SBOwnTextMorph >> drawOn: aCanvas [
 
 	| font cursorX colorToUse |
@@ -314,24 +320,18 @@ SBOwnTextMorph >> font: aFont [
 ]
 
 { #category : #'as yet unclassified' }
-SBOwnTextMorph >> fontToUse [
-
-	^ (font ifNil: [TextStyle defaultFont]) emphasized: self effectiveEmphasis emphasisCode
-]
-
-{ #category : #'as yet unclassified' }
 SBOwnTextMorph >> fullContents [
 
 	^ contents, suffix
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'event handling' }
 SBOwnTextMorph >> handlesKeyboard: anEvent [
 
 	^ false
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'event handling' }
 SBOwnTextMorph >> handlesMouseDown: anEvent [
 
 	^ false
@@ -343,7 +343,7 @@ SBOwnTextMorph >> hasCursor [
 	^ cursor > 0
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #initialization }
 SBOwnTextMorph >> initialize [
 
 	super initialize.
@@ -377,7 +377,7 @@ SBOwnTextMorph >> insertString: aString [
 	self moveCursorTo: self cursor + aString size
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'change reporting' }
 SBOwnTextMorph >> invalidRect: aRectangle [
 
 	^ super invalidRect: (aRectangle expandBy: 2)
@@ -395,7 +395,7 @@ SBOwnTextMorph >> isCursorAtStart [
 	^ self cursor = 1
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #classification }
 SBOwnTextMorph >> isTextMorph [
 
 	^ true
@@ -407,7 +407,7 @@ SBOwnTextMorph >> italic [
 	self emphasis: TextEmphasis italic
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'event handling' }
 SBOwnTextMorph >> keyStroke: anEvent [
 
 	| char |
@@ -424,7 +424,7 @@ SBOwnTextMorph >> keyStroke: anEvent [
 	(anEvent commandKeyPressed not and: [char isPrintable]) ifTrue: [self insertString: char asString]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'event handling' }
 SBOwnTextMorph >> keyboardFocusChange: weHaveFocus [
 
 	self changed
@@ -436,7 +436,7 @@ SBOwnTextMorph >> maxWidth: aNumber [
 	
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #layout }
 SBOwnTextMorph >> minExtent [
 
 	| font |
@@ -444,7 +444,7 @@ SBOwnTextMorph >> minExtent [
 	^ (font widthOfString: self contentsToDisplay) @ font height max: 4 @ font height
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'event handling' }
 SBOwnTextMorph >> mouseDown: anEvent [
 
 	anEvent hand newKeyboardFocus: self
@@ -548,7 +548,7 @@ SBOwnTextMorph >> tiny [
 	self font: (TextStyle default fontOfSize: 6)
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SBOwnTextMorph >> userString [
 
 	^ self contentsForEdit
@@ -560,13 +560,13 @@ SBOwnTextMorph >> verySmall [
 	self font: (TextStyle default fontOfSize: 6 sbScaled)
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'event handling' }
 SBOwnTextMorph >> wantsKeyboardFocus [
 
 	^ false
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #menu }
 SBOwnTextMorph >> wantsMetaMenu [
 
 	^ false

--- a/packages/Sandblocks-Smalltalk/SBStMessageSend.class.st
+++ b/packages/Sandblocks-Smalltalk/SBStMessageSend.class.st
@@ -45,7 +45,7 @@ SBStMessageSend >> asExample [
 			args: (SBStArray new
 				type: #dynamic
 				contents: self arguments veryDeepCopy)
-			label: 'example'
+			label: SBExample nameSuggestion
 ]
 
 { #category : #converting }

--- a/packages/Sandblocks-Smalltalk/SBVariant.class.st
+++ b/packages/Sandblocks-Smalltalk/SBVariant.class.st
@@ -223,13 +223,10 @@ SBVariant >> asProxy [
 { #category : #actions }
 SBVariant >> backtrack [
 	<action>
-
-	SBExploriants uniqueInstance isInEditor 
-		ifTrue: [
-			self sandblockEditor openMorphInView: 
-				(SBExploriants uniqueInstance historyView 
-					backtrackForPermutationName: (self name, ': ', (self alternatives at: self activeIndex) nameToDisplay))] 
-
+	
+	SBExploriants 
+		backtrack: #backtrackForPermutationName: 
+		withArguments: {(self name, ': ', (self alternatives at: self activeIndex) nameToDisplay)}
 ]
 
 { #category : #actions }

--- a/packages/Sandblocks-Smalltalk/SBVariant.class.st
+++ b/packages/Sandblocks-Smalltalk/SBVariant.class.st
@@ -221,6 +221,18 @@ SBVariant >> asProxy [
 ]
 
 { #category : #actions }
+SBVariant >> backtrack [
+	<action>
+
+	SBExploriants uniqueInstance isInEditor 
+		ifTrue: [
+			self sandblockEditor openMorphInView: 
+				(SBExploriants uniqueInstance historyView 
+					backtrackForPermutationName: (self name, ': ', (self alternatives at: self activeIndex) nameToDisplay))] 
+
+]
+
+{ #category : #actions }
 SBVariant >> beActive [
 	<action>
 


### PR DESCRIPTION
**Usage** 
Call the action 'backtrack' (alt , on block) on either Examples, Variation Points, or Example Watches to create a filtered copy of the current History that only includes the selected widget. Nothing will be displayed if Exploriants is not open in the Sandblocks Editor.  

The pictures below show an example of backtracking the example 'big' (1) and displays the filtered copy to the right of the original history (2).
![image](https://github.com/user-attachments/assets/ba492c2a-466f-41cb-ad52-980a1f7ab794)
![image](https://github.com/user-attachments/assets/4c652504-a95d-40fe-9ec7-c05101f617db)

**Code changes**
- Introduces a 'SBTag' class which can be added to the new #SBTag property of Morphs. A tag captures the widgets' state used to generate the Morph
- Using the function 'snapshotSatisfying:' on a Morph creates a filtered copy which only includes the given tags. Non-tagged Morphs are turned into images. So, typically, the resulted copy will be a mix of the original tagged Morphs and ImageMorphs inbetween. Subclasses can overwrite this method to create custom copy behavior (see SBTabView).
- 'layoutedTaggedCopy' describes how the Morph should be copied to create an "empty template" of it and must be considered when using the new API
- Few bug fixes